### PR TITLE
Security Module

### DIFF
--- a/docs/key-pairs.md
+++ b/docs/key-pairs.md
@@ -1,0 +1,452 @@
+# SSH Key Pair Management
+
+## Overview
+
+This document explains how SSH key pairs are generated, managed, and used for EC2 instance access in this project. The implementation uses Terraform to automatically generate RSA key pairs, store them locally, and register them with AWS.
+
+## Architecture
+
+### Key Pair Generation Flow
+
+```
+┌─────────────────────┐
+│  tls_private_key    │  1. Generate RSA 4096-bit key pair
+│  (Terraform)        │
+└──────────┬──────────┘
+           │
+           ├─────────────────────────────────────┐
+           │                                     │
+           ▼                                     ▼
+┌─────────────────────┐              ┌─────────────────────┐
+│  local_file         │              │  aws_key_pair       │
+│  (Private Key)      │              │  (Public Key)       │
+│                     │              │                     │
+│  Location:          │              │  Registered in AWS  │
+│  ssh-keys/*.pem     │              │  EC2 Key Pairs      │
+└─────────────────────┘              └─────────────────────┘
+```
+
+## Implementation Details
+
+### Module Structure
+
+```
+modules/create-key-pair/
+├── providers.tf      # AWS, TLS, and null providers
+├── variables.tf      # Input variables
+├── outputs.tf        # Key pair name, ARN, fingerprint, path
+└── key-pair.tf       # Key generation and storage logic
+```
+
+### Key Generation Process
+
+#### 1. Generate Private Key
+
+```terraform
+resource "tls_private_key" "this" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+```
+
+**Details:**
+- **Algorithm**: RSA (industry standard for SSH)
+- **Key Size**: 4096 bits (high security, recommended for production)
+- **Provider**: HashiCorp TLS provider
+- **Output**: Private key in PEM format, public key in OpenSSH format
+
+#### 2. Create SSH Directory
+
+```terraform
+resource "null_resource" "create_ssh_dir" {
+  provisioner "local-exec" {
+    command     = "mkdir -p ${var.project_root}/ssh-keys"
+    interpreter = ["/bin/sh", "-c"]
+  }
+}
+```
+
+**Purpose:**
+- Ensures `ssh-keys/` directory exists before writing keys
+- Uses `mkdir -p` for idempotent directory creation
+- Runs on the local machine executing Terraform
+
+#### 3. Save Private Key Locally
+
+```terraform
+resource "local_file" "private_key" {
+  depends_on = [null_resource.create_ssh_dir]
+
+  content         = tls_private_key.this.private_key_pem
+  filename        = "${var.project_root}/ssh-keys/${var.aws_region_short}-${var.environment}.pem"
+  file_permission = "0400"
+}
+```
+
+**Details:**
+- **Location**: `ssh-keys/{region_short}-{environment}.pem`
+- **Permissions**: `0400` (read-only for owner, required by SSH)
+- **Format**: PEM (Privacy Enhanced Mail)
+- **Dependency**: Waits for directory creation
+
+**Example Paths:**
+- `ssh-keys/euw2-dev.pem`
+- `ssh-keys/use1-prod.pem`
+- `ssh-keys/euw1-stage.pem`
+
+#### 4. Register Public Key with AWS
+
+```terraform
+resource "aws_key_pair" "this" {
+  key_name   = "kp-${var.aws_region_short}-${var.environment}"
+  public_key = tls_private_key.this.public_key_openssh
+
+  tags = merge(
+    var.default_tags,
+    {
+      Name = "kp-${var.aws_region_short}-${var.environment}"
+    }
+  )
+}
+```
+
+**Details:**
+- **Naming**: `kp-{region_short}-{environment}` (e.g., `kp-euw2-dev`)
+- **Format**: OpenSSH public key format
+- **Registration**: Stored in AWS EC2 Key Pairs service
+- **Scope**: Regional (key pair exists per region)
+
+## Idempotency
+
+### How Terraform Handles Idempotency
+
+Terraform automatically manages idempotency for key pair resources:
+
+#### First Run (Create)
+```bash
+terraform apply
+```
+- Generates new RSA key pair
+- Creates `ssh-keys/` directory
+- Writes private key to local file
+- Registers public key with AWS
+- Stores key metadata in Terraform state
+
+#### Subsequent Runs (No Changes)
+```bash
+terraform apply
+# Output: No changes. Your infrastructure matches the configuration.
+```
+
+**Terraform checks:**
+1. **State File**: Compares current state with desired configuration
+2. **Key Pair Name**: Checks if `kp-{region}-{env}` exists in AWS
+3. **Public Key**: Verifies public key matches what's in AWS
+4. **Local File**: Checks if private key file exists with correct permissions
+
+**Result**: If everything matches, Terraform makes no changes.
+
+#### Handling Changes
+
+**Scenario 1: Key Pair Deleted from AWS**
+```bash
+# Manually delete key pair from AWS Console
+terraform apply
+# Terraform will re-register the public key (same key pair)
+```
+
+**Scenario 2: Local Private Key Deleted**
+```bash
+# Manually delete ssh-keys/euw2-dev.pem
+terraform apply
+# Terraform will recreate the file from state
+```
+
+**Scenario 3: Terraform State Lost**
+```bash
+# State file deleted or corrupted
+terraform apply
+# ERROR: Key pair already exists in AWS
+# Solution: Import existing key pair or delete from AWS
+```
+
+### Import Existing Key Pair
+
+If you need to import an existing AWS key pair:
+
+```bash
+terraform import module.key_pair.aws_key_pair.this kp-euw2-dev
+```
+
+**Note**: You must have the private key file already in place.
+
+## Usage
+
+### Module Invocation
+
+```terraform
+module "key_pair" {
+  source           = "../../../modules/create-key-pair"
+  project_root     = local.project_root
+  aws_region_short = local.region_short
+  environment      = local.environment
+  default_tags     = local.default_tags
+}
+```
+
+### Using Key Pair with EC2 Instances
+
+```terraform
+resource "aws_instance" "bastion" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  key_name      = module.key_pair.key_pair_name  # Reference the key pair
+  
+  # ... other configuration
+}
+```
+
+### SSH Connection
+
+```bash
+# Connect to EC2 instance
+ssh -i ssh-keys/euw2-dev.pem ubuntu@<instance-public-ip>
+
+# With verbose output for debugging
+ssh -v -i ssh-keys/euw2-dev.pem ubuntu@<instance-public-ip>
+```
+
+## Fingerprint Verification
+
+### What is a Fingerprint?
+
+A fingerprint is a short hash of the public key used to verify key authenticity. AWS displays the MD5 fingerprint in the EC2 console.
+
+### Check Local Key Fingerprint (MD5)
+
+#### Method 1: Using OpenSSL (Recommended)
+
+```bash
+# Generate MD5 fingerprint from private key
+openssl pkey -in ssh-keys/euw2-dev.pem -pubout -outform DER | \
+  openssl md5 -c
+```
+
+**Output:**
+```
+(stdin)= 12:34:56:78:9a:bc:de:f0:12:34:56:78:9a:bc:de:f0
+```
+
+#### Method 2: Using ssh-keygen
+
+```bash
+# Extract public key from private key
+ssh-keygen -y -f ssh-keys/euw2-dev.pem > /tmp/temp_public_key.pub
+
+# Generate MD5 fingerprint
+ssh-keygen -l -E md5 -f /tmp/temp_public_key.pub
+
+# Clean up
+rm /tmp/temp_public_key.pub
+```
+
+**Output:**
+```
+4096 MD5:12:34:56:78:9a:bc:de:f0:12:34:56:78:9a:bc:de:f0 no comment (RSA)
+```
+
+#### Method 3: Using Terraform Output
+
+```bash
+# Get fingerprint from Terraform state
+terraform output -json | jq -r '.key_pair_fingerprint.value'
+```
+
+**Output:**
+```
+12:34:56:78:9a:bc:de:f0:12:34:56:78:9a:bc:de:f0
+```
+
+### Verify Against AWS Console
+
+1. Navigate to **EC2 Console** → **Key Pairs**
+2. Find your key pair (e.g., `kp-euw2-dev`)
+3. Compare the **Fingerprint** column with your local fingerprint
+4. They should match exactly
+
+### Verify Using AWS CLI
+
+```bash
+# Get key pair fingerprint from AWS
+aws ec2 describe-key-pairs \
+  --key-names kp-euw2-dev \
+  --query 'KeyPairs[0].KeyFingerprint' \
+  --output text
+```
+
+**Output:**
+```
+12:34:56:78:9a:bc:de:f0:12:34:56:78:9a:bc:de:f0
+```
+
+## Security Best Practices
+
+### File Permissions
+
+**Private Key:**
+```bash
+# Correct permissions (read-only for owner)
+chmod 400 ssh-keys/euw2-dev.pem
+
+# Verify permissions
+ls -l ssh-keys/euw2-dev.pem
+# Output: -r-------- 1 user group 3243 Feb 10 16:00 ssh-keys/euw2-dev.pem
+```
+
+**Why 0400?**
+- SSH requires private keys to be readable only by the owner
+- Prevents accidental modification or deletion
+- Protects against unauthorized access
+
+### Git Ignore
+
+Ensure private keys are never committed to version control:
+
+```gitignore
+# .gitignore
+ssh-keys/
+*.pem
+*.key
+```
+
+### Key Rotation
+
+**Recommended Schedule:**
+- **Development**: Every 6 months
+- **Production**: Every 3 months
+- **After Security Incident**: Immediately
+
+**Rotation Process:**
+1. Generate new key pair (change environment name or add version)
+2. Update EC2 instances with new key
+3. Test SSH access with new key
+4. Remove old key pair from AWS
+5. Delete old private key file
+6. Update Terraform state
+
+### Backup Strategy
+
+**Private Keys:**
+- Store in encrypted password manager (1Password, LastPass)
+- Use encrypted backup storage (AWS Secrets Manager, HashiCorp Vault)
+- Never store in plain text on shared drives
+
+**Recovery:**
+- If private key is lost, you cannot recover it
+- You must generate a new key pair
+- Update all EC2 instances using the old key
+
+## Troubleshooting
+
+### Permission Denied (publickey)
+
+**Error:**
+```
+Permission denied (publickey).
+```
+
+**Solutions:**
+
+1. **Check file permissions:**
+   ```bash
+   chmod 400 ssh-keys/euw2-dev.pem
+   ```
+
+2. **Verify correct key:**
+   ```bash
+   ssh -i ssh-keys/euw2-dev.pem ubuntu@<ip>
+   ```
+
+3. **Check instance key pair:**
+   ```bash
+   aws ec2 describe-instances --instance-ids i-xxxxx \
+     --query 'Reservations[0].Instances[0].KeyName'
+   ```
+
+4. **Verify fingerprint matches:**
+   ```bash
+   # Local fingerprint
+   openssl pkey -in ssh-keys/euw2-dev.pem -pubout -outform DER | openssl md5 -c
+   
+   # AWS fingerprint
+   aws ec2 describe-key-pairs --key-names kp-euw2-dev \
+     --query 'KeyPairs[0].KeyFingerprint' --output text
+   ```
+
+### Key Pair Already Exists
+
+**Error:**
+```
+Error: InvalidKeyPair.Duplicate: The keypair 'kp-euw2-dev' already exists.
+```
+
+**Solutions:**
+
+1. **Import existing key pair:**
+   ```bash
+   terraform import module.key_pair.aws_key_pair.this kp-euw2-dev
+   ```
+
+2. **Delete from AWS and recreate:**
+   ```bash
+   aws ec2 delete-key-pair --key-name kp-euw2-dev
+   terraform apply
+   ```
+
+3. **Use different name:**
+   - Change `environment` variable
+   - Or modify key pair naming in module
+
+### Wrong Fingerprint
+
+**Issue:** Local fingerprint doesn't match AWS fingerprint
+
+**Cause:** Different key pair registered in AWS
+
+**Solution:**
+1. Delete key pair from AWS
+2. Run `terraform apply` to re-register
+3. Verify fingerprints match
+
+## Module Outputs
+
+The key pair module provides the following outputs:
+
+```terraform
+output "key_pair_name" {
+  description = "The AWS key pair name"
+  value       = "kp-euw2-dev"
+}
+
+output "key_pair_arn" {
+  description = "The AWS key pair ARN"
+  value       = "arn:aws:ec2:eu-west-2:123456789012:key-pair/kp-euw2-dev"
+}
+
+output "key_pair_fingerprint" {
+  description = "The AWS key pair fingerprint (MD5)"
+  value       = "12:34:56:78:9a:bc:de:f0:12:34:56:78:9a:bc:de:f0"
+}
+
+output "private_key_path" {
+  description = "Local path to the private key file"
+  value       = "/path/to/project/ssh-keys/euw2-dev.pem"
+}
+```
+
+## References
+
+- [AWS EC2 Key Pairs Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
+- [Terraform TLS Provider](https://registry.terraform.io/providers/hashicorp/tls/latest/docs)
+- [OpenSSH Key Format](https://www.openssh.com/txt/rfc5656.txt)
+- [SSH Best Practices](https://www.ssh.com/academy/ssh/key-management)

--- a/envs/dev/euw2/ec2s.tf
+++ b/envs/dev/euw2/ec2s.tf
@@ -4,7 +4,7 @@ module "ec2" {
   aws_region_short = local.region_short
   environment      = local.environment
   vpc_id           = module.vpc-main.vpc.id
-  vpc_name         = local.vpc_name  # Dynamic from locals
+  vpc_name         = local.vpc_name # Dynamic from locals
   default_tags     = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets

--- a/envs/dev/euw2/ec2s.tf
+++ b/envs/dev/euw2/ec2s.tf
@@ -4,12 +4,14 @@ module "ec2" {
   aws_region_short = local.region_short
   environment      = local.environment
   vpc_id           = module.vpc-main.vpc.id
-  vpc_name         = "main"
+  vpc_name         = local.vpc_name  # Dynamic from locals
   default_tags     = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets
   private_subnets = module.vpc-main.private_subnets
   key_pair_name   = module.key_pair.key_pair_name
 
-  # Using VPC default security groups (Phase 5 will add custom SGs)
+  # Using custom security groups from security module
+  public_security_group_id  = module.security.bastion_security_group_id
+  private_security_group_id = module.security.private_security_group_id
 }

--- a/envs/dev/euw2/locals.tf
+++ b/envs/dev/euw2/locals.tf
@@ -1,7 +1,10 @@
 locals {
   region        = "eu-west-2"
+  aws_region    = "eu-west-2"  # Added for security module
   region_short  = "euw2"
+  aws_region_short = "euw2"  # Added for security module
   environment   = "dev"
+  vpc_name      = "${local.region_short}-${local.environment}"  # Dynamic naming convention
   project_root  = pathexpand("~/repos/aws-global-network")
 
   default_tags = {

--- a/envs/dev/euw2/locals.tf
+++ b/envs/dev/euw2/locals.tf
@@ -1,18 +1,18 @@
 locals {
-  region        = "eu-west-2"
-  aws_region    = "eu-west-2"  # Added for security module
-  region_short  = "euw2"
-  aws_region_short = "euw2"  # Added for security module
-  environment   = "dev"
-  vpc_name      = "${local.region_short}-${local.environment}"  # Dynamic naming convention
-  project_root  = pathexpand("~/repos/aws-global-network")
+  region           = "eu-west-2"
+  aws_region       = "eu-west-2" # Added for security module
+  region_short     = "euw2"
+  aws_region_short = "euw2" # Added for security module
+  environment      = "dev"
+  vpc_name         = "${local.region_short}-${local.environment}" # Dynamic naming convention
+  project_root     = pathexpand("~/repos/aws-global-network")
 
   default_tags = {
     owning_team          = "NETENG"
     managed_by_terraform = true
-    environment         = local.environment
-    region            = local.region
-    region_short      = local.region_short
+    environment          = local.environment
+    region               = local.region
+    region_short         = local.region_short
   }
 
   private_subnets = {

--- a/envs/dev/euw2/security.tf
+++ b/envs/dev/euw2/security.tf
@@ -1,0 +1,11 @@
+module "security" {
+  source           = "../../../modules/security"
+  vpc_id           = module.vpc-main.vpc.id
+  vpc_cidr         = module.vpc-main.vpc.cidr_block  # From VPC module output
+  aws_region_short = local.region_short
+  environment      = local.environment
+  default_tags     = local.default_tags
+  
+  public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]
+  private_subnet_ids = [for k, v in module.vpc-main.private_subnets : v.id]
+}

--- a/envs/dev/euw2/security.tf
+++ b/envs/dev/euw2/security.tf
@@ -1,11 +1,11 @@
 module "security" {
   source           = "../../../modules/security"
   vpc_id           = module.vpc-main.vpc.id
-  vpc_cidr         = module.vpc-main.vpc.cidr_block  # From VPC module output
+  vpc_cidr         = module.vpc-main.vpc.cidr_block # From VPC module output
   aws_region_short = local.region_short
   environment      = local.environment
   default_tags     = local.default_tags
-  
+
   public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]
   private_subnet_ids = [for k, v in module.vpc-main.private_subnets : v.id]
 }

--- a/envs/dev/euw2/vpc.tf
+++ b/envs/dev/euw2/vpc.tf
@@ -4,7 +4,7 @@ module "vpc-main" {
   aws_region       = local.region
   aws_region_short = local.region_short
   environment      = local.environment
-  vpc_name         = local.vpc_name  # Dynamic from locals
+  vpc_name         = local.vpc_name # Dynamic from locals
   vpc_cidr         = "10.0.0.0/20"
   default_tags     = local.default_tags
 

--- a/envs/dev/euw2/vpc.tf
+++ b/envs/dev/euw2/vpc.tf
@@ -4,7 +4,7 @@ module "vpc-main" {
   aws_region       = local.region
   aws_region_short = local.region_short
   environment      = local.environment
-  vpc_name         = "main"
+  vpc_name         = local.vpc_name  # Dynamic from locals
   vpc_cidr         = "10.0.0.0/20"
   default_tags     = local.default_tags
 

--- a/envs/test/ec2-test/locals.tf
+++ b/envs/test/ec2-test/locals.tf
@@ -1,17 +1,17 @@
 locals {
-  region       = "eu-west-2"
-  aws_region    = "eu-west-2"  # Added for security module
-  region_short = "euw2"
-  aws_region_short = "euw2"  # Added for security module
-  environment  = "ec2-test"
-  vpc_name      = "${local.region_short}-${local.environment}"  # Dynamic naming convention
-  project_root = pathexpand("~/repos/aws-global-network")
+  region           = "eu-west-2"
+  aws_region       = "eu-west-2" # Added for security module
+  region_short     = "euw2"
+  aws_region_short = "euw2" # Added for security module
+  environment      = "ec2-test"
+  vpc_name         = "${local.region_short}-${local.environment}" # Dynamic naming convention
+  project_root     = pathexpand("~/repos/aws-global-network")
 
   default_tags = {
     owning_team          = "NETENG"
     managed_by_terraform = true
-    environment         = local.environment
-    region            = local.region
-    region_short      = local.region_short
+    environment          = local.environment
+    region               = local.region
+    region_short         = local.region_short
   }
 }

--- a/envs/test/ec2-test/locals.tf
+++ b/envs/test/ec2-test/locals.tf
@@ -1,7 +1,10 @@
 locals {
   region       = "eu-west-2"
+  aws_region    = "eu-west-2"  # Added for security module
   region_short = "euw2"
+  aws_region_short = "euw2"  # Added for security module
   environment  = "ec2-test"
+  vpc_name      = "${local.region_short}-${local.environment}"  # Dynamic naming convention
   project_root = pathexpand("~/repos/aws-global-network")
 
   default_tags = {

--- a/envs/test/ec2-test/main.tf
+++ b/envs/test/ec2-test/main.tf
@@ -11,7 +11,7 @@ module "test_vpc" {
   aws_region       = local.region
   aws_region_short = local.region_short
   environment      = local.environment
-  vpc_name         = "${local.region_short}-${local.environment}"
+  vpc_name         = local.vpc_name
   vpc_cidr         = "10.0.0.0/16"
   default_tags     = local.default_tags
 
@@ -43,9 +43,9 @@ module "test_ec2" {
   private_subnets = module.test_vpc.private_subnets
   key_pair_name   = module.test_key_pair.key_pair_name
 
-  # Security groups are optional - using VPC default
-  # public_security_group_id  = null  # (default)
-  # private_security_group_id = null  # (default)
+  # Using custom security groups from security module
+  public_security_group_id  = module.security.bastion_security_group_id
+  private_security_group_id = module.security.private_security_group_id
 }
 
 output "key_pair_name" {

--- a/envs/test/ec2-test/security.tf
+++ b/envs/test/ec2-test/security.tf
@@ -1,0 +1,11 @@
+module "security" {
+  source           = "../../../modules/security"
+  vpc_id           = module.test_vpc.vpc.id
+  vpc_cidr         = module.test_vpc.vpc.cidr_block  # From VPC module output
+  aws_region_short = local.region_short
+  environment      = local.environment
+  default_tags     = local.default_tags
+  
+  public_subnet_ids  = [for k, v in module.test_vpc.public_subnets : v.id]
+  private_subnet_ids = [for k, v in module.test_vpc.private_subnets : v.id]
+}

--- a/envs/test/ec2-test/security.tf
+++ b/envs/test/ec2-test/security.tf
@@ -1,11 +1,11 @@
 module "security" {
   source           = "../../../modules/security"
   vpc_id           = module.test_vpc.vpc.id
-  vpc_cidr         = module.test_vpc.vpc.cidr_block  # From VPC module output
+  vpc_cidr         = module.test_vpc.vpc.cidr_block # From VPC module output
   aws_region_short = local.region_short
   environment      = local.environment
   default_tags     = local.default_tags
-  
+
   public_subnet_ids  = [for k, v in module.test_vpc.public_subnets : v.id]
   private_subnet_ids = [for k, v in module.test_vpc.private_subnets : v.id]
 }

--- a/envs/test/keypair-test/locals.tf
+++ b/envs/test/keypair-test/locals.tf
@@ -7,8 +7,8 @@ locals {
   default_tags = {
     owning_team          = "NETENG"
     managed_by_terraform = true
-    environment         = local.environment
-    region            = local.region
-    region_short      = local.region_short
+    environment          = local.environment
+    region               = local.region
+    region_short         = local.region_short
   }
 }

--- a/modules/create-ec2/variables.tf
+++ b/modules/create-ec2/variables.tf
@@ -1,5 +1,5 @@
 variable "default_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Default tags to apply to all resources"
 }
 

--- a/modules/create-key-pair/key-pair.tf
+++ b/modules/create-key-pair/key-pair.tf
@@ -18,6 +18,7 @@ resource "local_file" "private_key" {
   file_permission = "0400"
 }
 
+# Terraform handles idempotency
 resource "aws_key_pair" "this" {
   key_name   = "kp-${var.aws_region_short}-${var.environment}"
   public_key = tls_private_key.this.public_key_openssh

--- a/modules/create-key-pair/outputs.tf
+++ b/modules/create-key-pair/outputs.tf
@@ -7,3 +7,13 @@ output "key_pair_arn" {
   description = "The AWS key pair ARN"
   value       = aws_key_pair.this.arn
 }
+
+output "key_pair_fingerprint" {
+  description = "The AWS key pair fingerprint"
+  value       = aws_key_pair.this.fingerprint
+}
+
+output "private_key_path" {
+  description = "Local path to the private key file"
+  value       = "${var.project_root}/ssh-keys/${var.aws_region_short}-${var.environment}.pem"
+}

--- a/modules/create-key-pair/variables.tf
+++ b/modules/create-key-pair/variables.tf
@@ -14,6 +14,6 @@ variable "environment" {
 }
 
 variable "default_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Default tags to apply to resources"
 }

--- a/modules/create-vpc/gateways.tf
+++ b/modules/create-vpc/gateways.tf
@@ -34,5 +34,16 @@ resource "awscc_ec2_nat_gateway" "this" {
     ]
   )
 
+  lifecycle {
+  # 1 - When you create a NAT Gateway in "regional" - "auto" mode, AWS automatically assigns 
+  # and manages the Elastic IP (EIP) addresses and their associations.
+  # 2 - After the NAT Gateway is created, AWS populates the availability_zone_addresses attribute with these details.
+  # 3 - Because these values weren't in the original Terraform code, Terraform sees them as "extra" or 
+  # "unexpected" changes during the next run and tries to remove them.
+    ignore_changes = [
+      availability_zone_addresses
+    ]
+  }
+
   depends_on = [aws_internet_gateway.this]
 }

--- a/modules/create-vpc/routes.tf
+++ b/modules/create-vpc/routes.tf
@@ -6,7 +6,7 @@ resource "aws_route_table" "private" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("rtb-%s-%s-${each.key}", var.aws_region_short, var.environment)
+      Name  = format("rtb-%s-%s-${each.key}", var.aws_region_short, var.environment)
       scope = local.private_subnets_tag
     }
   )
@@ -36,7 +36,7 @@ resource "aws_route_table" "public" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("rtb-%s-%s-${each.key}", var.aws_region_short, var.environment)
+      Name  = format("rtb-%s-%s-${each.key}", var.aws_region_short, var.environment)
       scope = local.public_subnets_tag
     }
   )

--- a/modules/create-vpc/subnets.tf
+++ b/modules/create-vpc/subnets.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "private" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("sub-%s-%s-${each.key}", var.aws_region_short, var.environment)
+      Name  = format("sub-%s-%s-${each.key}", var.aws_region_short, var.environment)
       scope = "private"
     }
   )
@@ -37,7 +37,7 @@ resource "aws_subnet" "public" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("sub-%s-%s-${each.key}", var.aws_region_short, var.environment)
+      Name  = format("sub-%s-%s-${each.key}", var.aws_region_short, var.environment)
       scope = "public"
     }
   )

--- a/modules/create-vpc/variables.tf
+++ b/modules/create-vpc/variables.tf
@@ -1,5 +1,5 @@
 variable "default_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Default tags to apply to all resources"
 }
 

--- a/modules/security/nacls.tf
+++ b/modules/security/nacls.tf
@@ -2,7 +2,7 @@
 resource "aws_network_acl" "public" {
   vpc_id     = var.vpc_id
   subnet_ids = var.public_subnet_ids
-  
+
   tags = merge(var.default_tags, {
     Name = format("nacl-public-%s-%s", var.aws_region_short, var.environment)
     type = "public-nacl"
@@ -13,7 +13,7 @@ resource "aws_network_acl" "public" {
 resource "aws_network_acl" "private" {
   vpc_id     = var.vpc_id
   subnet_ids = var.private_subnet_ids
-  
+
   tags = merge(var.default_tags, {
     Name = format("nacl-private-%s-%s", var.aws_region_short, var.environment)
     type = "private-nacl"
@@ -54,6 +54,53 @@ resource "aws_network_acl_rule" "public_inbound_https" {
   to_port        = 443
 }
 
+# Allow ICMP (ping) for IPv4
+resource "aws_network_acl_rule" "public_inbound_icmp" {
+  network_acl_id = aws_network_acl.public.id
+  rule_number    = 130
+  egress         = false
+  protocol       = "icmp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  icmp_type      = -1
+  icmp_code      = -1
+}
+
+# Allow ICMPv6 for IPv6
+resource "aws_network_acl_rule" "public_inbound_icmpv6" {
+  network_acl_id  = aws_network_acl.public.id
+  rule_number     = 140
+  egress          = false
+  protocol        = "58"
+  rule_action     = "allow"
+  ipv6_cidr_block = "::/0"
+  icmp_type       = -1
+  icmp_code       = -1
+}
+
+# Public NACL Egress Rules
+resource "aws_network_acl_rule" "public_outbound_all" {
+  network_acl_id = aws_network_acl.public.id
+  rule_number    = 100
+  egress         = true
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 0
+  to_port        = 0
+}
+
+resource "aws_network_acl_rule" "public_outbound_ipv6" {
+  network_acl_id  = aws_network_acl.public.id
+  rule_number     = 110
+  egress          = true
+  protocol        = "-1"
+  rule_action     = "allow"
+  ipv6_cidr_block = "::/0"
+  from_port       = 0
+  to_port         = 0
+}
+
 # Private NACL Rules
 resource "aws_network_acl_rule" "private_inbound_all" {
   network_acl_id = aws_network_acl.private.id
@@ -64,4 +111,27 @@ resource "aws_network_acl_rule" "private_inbound_all" {
   cidr_block     = var.vpc_cidr
   from_port      = 0
   to_port        = 0
+}
+
+# Private NACL Egress Rules
+resource "aws_network_acl_rule" "private_outbound_all" {
+  network_acl_id = aws_network_acl.private.id
+  rule_number    = 100
+  egress         = true
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 0
+  to_port        = 0
+}
+
+resource "aws_network_acl_rule" "private_outbound_ipv6" {
+  network_acl_id  = aws_network_acl.private.id
+  rule_number     = 110
+  egress          = true
+  protocol        = "-1"
+  rule_action     = "allow"
+  ipv6_cidr_block = "::/0"
+  from_port       = 0
+  to_port         = 0
 }

--- a/modules/security/nacls.tf
+++ b/modules/security/nacls.tf
@@ -1,0 +1,67 @@
+# Public Subnet NACL
+resource "aws_network_acl" "public" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.public_subnet_ids
+  
+  tags = merge(var.default_tags, {
+    Name = format("nacl-public-%s-%s", var.aws_region_short, var.environment)
+    type = "public-nacl"
+  })
+}
+
+# Private Subnet NACL
+resource "aws_network_acl" "private" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
+  
+  tags = merge(var.default_tags, {
+    Name = format("nacl-private-%s-%s", var.aws_region_short, var.environment)
+    type = "private-nacl"
+  })
+}
+
+# Public NACL Rules
+resource "aws_network_acl_rule" "public_inbound_ssh" {
+  network_acl_id = aws_network_acl.public.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_network_acl_rule" "public_inbound_http" {
+  network_acl_id = aws_network_acl.public.id
+  rule_number    = 110
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 80
+  to_port        = 80
+}
+
+resource "aws_network_acl_rule" "public_inbound_https" {
+  network_acl_id = aws_network_acl.public.id
+  rule_number    = 120
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
+# Private NACL Rules
+resource "aws_network_acl_rule" "private_inbound_all" {
+  network_acl_id = aws_network_acl.private.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = var.vpc_cidr
+  from_port      = 0
+  to_port        = 0
+}

--- a/modules/security/outputs.tf
+++ b/modules/security/outputs.tf
@@ -1,0 +1,19 @@
+output "bastion_security_group_id" {
+  description = "Security group ID for bastion instances"
+  value       = aws_security_group.bastion.id
+}
+
+output "private_security_group_id" {
+  description = "Security group ID for private instances"
+  value       = aws_security_group.private.id
+}
+
+output "public_network_acl_id" {
+  description = "Network ACL ID for public subnets"
+  value       = aws_network_acl.public.id
+}
+
+output "private_network_acl_id" {
+  description = "Network ACL ID for private subnets"
+  value       = aws_network_acl.private.id
+}

--- a/modules/security/providers.tf
+++ b/modules/security/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.31.0"
+    }
+  }
+}

--- a/modules/security/security-groups.tf
+++ b/modules/security/security-groups.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "bastion" {
   name_prefix = "bastion-"
   vpc_id      = var.vpc_id
-  
+
   # Only SSH on port 22 inbound allowed to bastions hosts (from everywhere)
   ingress {
     description = "SSH access from everywhere"
@@ -11,7 +11,25 @@ resource "aws_security_group" "bastion" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
+  # ICMPv4 (ping) from everywhere
+  ingress {
+    description = "ICMPv4 from everywhere"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # ICMPv6 from everywhere
+  ingress {
+    description      = "ICMPv6 from everywhere"
+    from_port        = -1
+    to_port          = -1
+    protocol         = "icmpv6"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
   # All TCP Outbound
   egress {
     description = "All TCP outbound"
@@ -20,7 +38,7 @@ resource "aws_security_group" "bastion" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   tags = merge(var.default_tags, {
     Name = format("sg-bastion-%s-%s", var.aws_region_short, var.environment)
     type = "bastion-security-group"
@@ -31,16 +49,16 @@ resource "aws_security_group" "bastion" {
 resource "aws_security_group" "private" {
   name_prefix = "private-"
   vpc_id      = var.vpc_id
-  
+
   # From bastions to private ec2 or subnets all allowed
   ingress {
-    description = "All traffic from bastion security group"
+    description     = "All traffic from bastion security group"
     from_port       = 0
     to_port         = 0
     protocol        = "-1"
     security_groups = [aws_security_group.bastion.id]
   }
-  
+
   # All TCP Outbound
   egress {
     description = "All TCP outbound"
@@ -49,7 +67,7 @@ resource "aws_security_group" "private" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   tags = merge(var.default_tags, {
     Name = format("sg-private-%s-%s", var.aws_region_short, var.environment)
     type = "private-security-group"

--- a/modules/security/security-groups.tf
+++ b/modules/security/security-groups.tf
@@ -1,0 +1,57 @@
+# Public Security Group (Bastion)
+resource "aws_security_group" "bastion" {
+  name_prefix = "bastion-"
+  vpc_id      = var.vpc_id
+  
+  # Only SSH on port 22 inbound allowed to bastions hosts (from everywhere)
+  ingress {
+    description = "SSH access from everywhere"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  # All TCP Outbound
+  egress {
+    description = "All TCP outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  tags = merge(var.default_tags, {
+    Name = format("sg-bastion-%s-%s", var.aws_region_short, var.environment)
+    type = "bastion-security-group"
+  })
+}
+
+# Private Security Group (Private EC2)
+resource "aws_security_group" "private" {
+  name_prefix = "private-"
+  vpc_id      = var.vpc_id
+  
+  # From bastions to private ec2 or subnets all allowed
+  ingress {
+    description = "All traffic from bastion security group"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [aws_security_group.bastion.id]
+  }
+  
+  # All TCP Outbound
+  egress {
+    description = "All TCP outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  tags = merge(var.default_tags, {
+    Name = format("sg-private-%s-%s", var.aws_region_short, var.environment)
+    type = "private-security-group"
+  })
+}

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where security groups will be created"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "VPC CIDR block for private security group rules"
+}
+
+variable "default_tags" {
+  type        = map(string)
+  description = "Default tags to apply to all security group resources"
+}
+
+variable "aws_region_short" {
+  type        = string
+  description = "Short region code for naming"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name for naming"
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  description = "List of public subnet IDs"
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "List of private subnet IDs"
+}


### PR DESCRIPTION
# Pull Request: Security Module Implementation

## Overview

Complete implementation of the security module providing network-level and instance-level security controls for VPC infrastructure. Includes security groups for bastion and private instances, plus stateless Network ACLs for subnet-level traffic filtering with full IPv4/IPv6 support.

## Summary

This PR delivers a production-ready security module that implements defense-in-depth with both security groups (stateful, instance-level) and NACLs (stateless, subnet-level). The module supports dual-stack networking with proper ICMP configuration for connectivity testing.

## Key Changes

### Security Groups

**Bastion Security Group (Public Tier):**
- SSH (port 22) inbound from anywhere (0.0.0.0/0)
- ICMPv4 inbound from anywhere (0.0.0.0/0) - enables ping
- ICMPv6 inbound from anywhere (::/0) - enables IPv6 ping
- All traffic outbound (protocol -1)

**Private Security Group (Private Tier):**
- All traffic inbound from bastion security group (security group reference, not CIDR)
- All traffic outbound (0.0.0.0/0)

### Network ACLs (Stateless)

**Public Subnet NACL:**
- Inbound rules: SSH (22), HTTP (80), HTTPS (443), ICMPv4, ICMPv6
- Outbound rules: All IPv4 (0.0.0.0/0), All IPv6 (::/0)

**Private Subnet NACL:**
- Inbound rules: All traffic from VPC CIDR
- Outbound rules: All IPv4 (0.0.0.0/0), All IPv6 (::/0)

## Technical Details

### Module structure
```bash
modules/security/
├── providers.tf           # AWS provider configuration
├── variables.tf           # VPC ID, CIDR, subnet IDs, tags
├── outputs.tf             # Security group and NACL IDs
├── security-groups.tf     # Bastion and private security groups
└── nacls.tf              # Public and private NACLs with rules
```
