### PR TITLE
EUW2 Keypairs + Scripts Update + Resource Naming Update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,35 @@ tflint --recursive --config=$PROJECT_NAME/tools/.tflint.hcl
 
 ## Terraform Resources Naming Convention
 
-- We will use the following naming convention across this project for Name labels: `${resource_shortname}-${var.region_short}-${var.environment}-{optional_info}`
-  - Example: sub-euw2-dev-priv-2 (Private Subnet)
-  - Example: rt-euw2-dev-priv-2 (Private Ruting Table Subnet)
+- We will use the following naming convention across this project for Name labels: `${resource_shortname}-${var.region_short}-${var.environment}-{optional_info}-${cell_name}`
+  - Example: sub-euw2-dev-priv-2-cell1000 (Private Subnet)
+  - Example: rtb-euw2-dev-priv-2-cell1000 (Private Route Table)
+  - Example: bastion-euw2-prod-pub-0-cell0000 (Bastion EC2 Instance)
+  - Example: sg-bastion-euw2-dev-cell1000 (Bastion Security Group)
+
+- Singleton/shared resources (TGW, TGW route tables, TGW attachments, key pairs) do NOT include cell_name:
+  - Example: tgw-euw2 (Transit Gateway)
+  - Example: rt-tgw-euw2-dev (TGW Route Table)
+  - Example: kp-euw2-dev (Key Pair)
 
 ### Resource Shortnames
 
-- NAT Gateways: ngw
-- Subnets: sub
-- Routing Table: rt
+- VPC: vpc
+- Internet Gateway: igw
+- Egress-only IPv6 IGW: egipv6-igw
+- NAT Gateway: ngw
+- Subnet: sub
+- Route Table: rtb
+- Bastion EC2: bastion
+- Private EC2: private
+- Bastion Security Group: sg-bastion
+- Private Security Group: sg-private
+- Public NACL: nacl-public
+- Private NACL: nacl-private
+- Transit Gateway: tgw
+- TGW Route Table: rt-tgw
+- TGW Attachment: tgw-att
+- Key Pair: kp
 
 ## NEVER DO THE FOLLOWING
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -196,7 +196,7 @@ module "key_pair" {
 - **AMI**: Ubuntu 24.04 LTS (Noble Numbat) with gp3 storage
   - Owner: Canonical (099720109477)
   - Pattern: `ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*`
-- **Naming**: `{subnet-key}-{region_short}-{environment}-{vpc_name}`
+- **Naming**: `{type}-{region_short}-{environment}-{subnet_key}-{cell_name}` (e.g., `bastion-euw2-prod-pub-0-cell0000`)
 - **Security Groups**: Optional with fallback to VPC default
   - Allows module testing without custom security groups
   - Uses conditional logic: `var.sg_id != null ? [var.sg_id] : [data.aws_security_group.default.id]`
@@ -584,7 +584,7 @@ modules/security/
 - **Stateless NACLs**: Explicit egress rules required for return traffic
 - **Security Group References**: Private SG allows all traffic from bastion SG (not CIDR-based)
 - **ICMP Support**: Both IPv4 (icmp) and IPv6 (protocol 58) enabled for connectivity testing
-- **Naming Convention**: `sg-{type}-{region_short}-{environment}` and `nacl-{type}-{region_short}-{environment}`
+- **Naming Convention**: `sg-{type}-{region_short}-{environment}-{cell_name}` and `nacl-{type}-{region_short}-{environment}-{cell_name}`
 
 ---
 

--- a/docs/tagging-strategy.md
+++ b/docs/tagging-strategy.md
@@ -36,7 +36,7 @@ All tags use **lowercase** keys with underscores for multi-word keys:
 | `environment` | Environment name | `"dev"`, `"prod"`, `"test"` | ✅ Yes |
 | `region` | AWS region | `"eu-west-2"` | ✅ Yes |
 | `region_short` | Short region code | `"euw2"` | ✅ Yes |
-| `name` | Resource-specific name | `"bastion-euw2-dev-pub-0"` | ✅ Yes |
+| `name` | Resource-specific name | `"bastion-euw2-dev-pub-0-cell1000"` | ✅ Yes |
 | `type` | Resource type classification | `"bastion"`, `"application"` | ✅ Yes |
 
 ### Name Tag Exception
@@ -46,7 +46,7 @@ All tags use **lowercase** keys with underscores for multi-word keys:
 - **Purpose**: Provides human-readable resource names in AWS Management Console
 - **Key Format**: Use PascalCase `Name` (not lowercase `name`)
 - **Usage**: Should be used alongside our standard lowercase tags
-- **Example**: `Name = "bastion-euw2-dev-pub-0"`
+- **Example**: `Name = "bastion-euw2-dev-pub-0-cell1000"`
 
 **Why this exception exists:**
 
@@ -61,7 +61,7 @@ All tags use **lowercase** keys with underscores for multi-word keys:
 tags = merge(
   var.default_tags,
   {
-    Name = format("bastion-%s-%s-%s", var.region_short, var.environment, each.key)  # PascalCase for GUI
+    Name = format("bastion-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)  # PascalCase for GUI
     type = "bastion"  # lowercase for our standard
   }
 )
@@ -143,7 +143,7 @@ resource "aws_instance" "example" {
   tags = merge(
     var.default_tags,
     {
-      name = format("bastion-%s-%s-%s", var.region_short, var.environment, each.key)
+      Name = format("bastion-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)
       type = "bastion"
     }
   )
@@ -174,7 +174,7 @@ variable "default_tags" {
 tags = merge(
   var.default_tags,
   {
-    name = format("resource-%s-%s-%s", var.region_short, var.environment, each.key)
+    Name = format("resource-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)
     type = "resource-type"
   }
 )
@@ -267,8 +267,8 @@ resource "aws_subnet" "public" {
   tags = merge(
     var.default_tags,
     {
-      name = format("sub-%s-%s-pub-%s", var.region_short, var.environment, each.key)
-      type = "public"
+      Name  = format("sub-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
+      scope = "public"
     }
   )
 }
@@ -295,12 +295,31 @@ resource "aws_subnet" "public" {
 
 ### Naming Conventions
 
-#### Resource Names
+#### Resource Names (Cell-Scoped)
 
-- **VPC**: `vpc-{region_short}-{environment}-{name}`
-- **Subnets**: `sub-{region_short}-{environment}-{type}-{number}`
-- **Instances**: `{type}-{region_short}-{environment}-{subnet}-{number}`
-- **Route Tables**: `rt-{region_short}-{environment}-{type}-{number}`
+Resources that belong to a specific VPC/cell include `{cell_name}` as the last segment:
+
+- **VPC**: `vpc-{region_short}-{environment}-{cell_name}`
+- **Subnets**: `sub-{region_short}-{environment}-{subnet_key}-{cell_name}`
+- **Route Tables**: `rtb-{region_short}-{environment}-{subnet_key}-{cell_name}`
+- **Bastion EC2**: `bastion-{region_short}-{environment}-{subnet_key}-{cell_name}`
+- **Private EC2**: `private-{region_short}-{environment}-{subnet_key}-{cell_name}`
+- **Internet Gateway**: `igw-{region_short}-{environment}-{cell_name}`
+- **Egress-only IPv6 IGW**: `egipv6-igw-{region_short}-{environment}-{cell_name}`
+- **NAT Gateway**: `ngw-{region_short}-{environment}-{cell_name}`
+- **Bastion Security Group**: `sg-bastion-{region_short}-{environment}-{cell_name}`
+- **Private Security Group**: `sg-private-{region_short}-{environment}-{cell_name}`
+- **Public NACL**: `nacl-public-{region_short}-{environment}-{cell_name}`
+- **Private NACL**: `nacl-private-{region_short}-{environment}-{cell_name}`
+
+#### Resource Names (Singleton/Shared — no cell_name)
+
+Resources that are shared across cells or are region-wide singletons:
+
+- **Transit Gateway**: `tgw-{region_short}`
+- **TGW Route Table**: `rt-tgw-{region_short}-{environment}`
+- **TGW Attachment**: `tgw-att-{region_short}-{environment}-{vpc_name}`
+- **Key Pair**: `kp-{region_short}-{environment}`
 
 #### Tag Values
 

--- a/envs/dev/euw1/keypair/.terraform.lock.hcl
+++ b/envs/dev/euw1/keypair/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.33.0"
+  constraints = ">= 6.31.0"
+  hashes = [
+    "h1:wNrviem6bg9fq1bYvtGqH9QWO6iWbM1bBRLSqFJWqWM=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/dev/euw1/keypair/backend.tf
+++ b/envs/dev/euw1/keypair/backend.tf
@@ -1,7 +1,7 @@
 # A backend block cannot refer to named values (like input variables, locals, or data source attributes).
 terraform {
   backend "s3" {
-    region       = "eu-west-1"
+    region       = "eu-west-2"
     bucket       = "dmac-bootstrap-tfstate"
     key          = "env-dev/euw1/keypair/terraform.tfstate"
     encrypt      = true

--- a/envs/dev/euw2/cell1000/ec2s.tf
+++ b/envs/dev/euw2/cell1000/ec2s.tf
@@ -5,6 +5,7 @@ module "ec2" {
   environment  = local.environment
   vpc_id       = module.vpc-main.vpc.id
   vpc_name     = local.vpc_name # Dynamic from locals
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets

--- a/envs/dev/euw2/cell1000/ec2s.tf
+++ b/envs/dev/euw2/cell1000/ec2s.tf
@@ -9,7 +9,7 @@ module "ec2" {
 
   public_subnets  = module.vpc-main.public_subnets
   private_subnets = module.vpc-main.private_subnets
-  key_pair_name   = module.key_pair.key_pair_name
+  key_pair_name   = data.aws_key_pair.this.key_name
 
   # Using custom security groups from security module
   public_security_group_id  = module.security.bastion_security_group_id

--- a/envs/dev/euw2/cell1000/keypair.tf
+++ b/envs/dev/euw2/cell1000/keypair.tf
@@ -1,7 +1,3 @@
-module "key_pair" {
-  source       = "../../../../modules/create-key-pair"
-  project_root = local.project_root
-  region_short = local.region_short
-  environment  = local.environment
-  default_tags = local.default_tags
+data "aws_key_pair" "this" {
+  key_name = "kp-${local.region_short}-${local.environment}"
 }

--- a/envs/dev/euw2/cell1000/outputs.tf
+++ b/envs/dev/euw2/cell1000/outputs.tf
@@ -90,11 +90,11 @@ output "instances" {
   value = {
     bastions = {
       for k, ip in module.ec2.bastion_public_ips :
-      format("bastion-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("bastion-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
     private_hosts = {
       for k, ip in module.ec2.private_instance_private_ips :
-      format("private-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("private-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
   }
 }

--- a/envs/dev/euw2/cell1000/outputs.tf
+++ b/envs/dev/euw2/cell1000/outputs.tf
@@ -101,5 +101,5 @@ output "instances" {
 
 output "ssh_key_path" {
   description = "Local path to the SSH private key for this cell"
-  value       = module.key_pair.private_key_path
+  value       = "${local.project_root}/ssh-keys/${local.region_short}-${local.environment}.pem"
 }

--- a/envs/dev/euw2/cell1000/security.tf
+++ b/envs/dev/euw2/cell1000/security.tf
@@ -4,6 +4,7 @@ module "security" {
   vpc_cidr     = module.vpc-main.vpc.cidr_block # From VPC module output
   region_short = local.region_short
   environment  = local.environment
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]

--- a/envs/dev/euw2/cell1000/vpc.tf
+++ b/envs/dev/euw2/cell1000/vpc.tf
@@ -5,6 +5,7 @@ module "vpc-main" {
   region_short = local.region_short
   environment  = local.environment
   vpc_name     = local.vpc_name # Dynamic from locals - includes cell name
+  cell_name    = local.cell_name
   vpc_cidr     = "10.1.0.0/20"
   default_tags = local.default_tags
 

--- a/envs/dev/euw2/cell1001/ec2s.tf
+++ b/envs/dev/euw2/cell1001/ec2s.tf
@@ -5,6 +5,7 @@ module "ec2" {
   environment  = local.environment
   vpc_id       = module.vpc-main.vpc.id
   vpc_name     = local.vpc_name # Dynamic from locals
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets

--- a/envs/dev/euw2/cell1001/outputs.tf
+++ b/envs/dev/euw2/cell1001/outputs.tf
@@ -90,11 +90,11 @@ output "instances" {
   value = {
     bastions = {
       for k, ip in module.ec2.bastion_public_ips :
-      format("bastion-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("bastion-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
     private_hosts = {
       for k, ip in module.ec2.private_instance_private_ips :
-      format("private-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("private-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
   }
 }

--- a/envs/dev/euw2/cell1001/security.tf
+++ b/envs/dev/euw2/cell1001/security.tf
@@ -4,6 +4,7 @@ module "security" {
   vpc_cidr     = module.vpc-main.vpc.cidr_block # From VPC module output
   region_short = local.region_short
   environment  = local.environment
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]

--- a/envs/dev/euw2/cell1001/vpc.tf
+++ b/envs/dev/euw2/cell1001/vpc.tf
@@ -5,6 +5,7 @@ module "vpc-main" {
   region_short = local.region_short
   environment  = local.environment
   vpc_name     = local.vpc_name # Dynamic from locals - includes cell name
+  cell_name    = local.cell_name
   vpc_cidr     = "10.1.16.0/20"
   default_tags = local.default_tags
 

--- a/envs/dev/euw2/keypair/.terraform.lock.hcl
+++ b/envs/dev/euw2/keypair/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.33.0"
+  constraints = ">= 6.31.0"
+  hashes = [
+    "h1:wNrviem6bg9fq1bYvtGqH9QWO6iWbM1bBRLSqFJWqWM=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/dev/euw2/keypair/backend.tf
+++ b/envs/dev/euw2/keypair/backend.tf
@@ -1,0 +1,10 @@
+# A backend block cannot refer to named values (like input variables, locals, or data source attributes).
+terraform {
+  backend "s3" {
+    region       = "eu-west-2"
+    bucket       = "dmac-bootstrap-tfstate"
+    key          = "env-dev/euw2/keypair/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/envs/dev/euw2/keypair/keypair.tf
+++ b/envs/dev/euw2/keypair/keypair.tf
@@ -1,0 +1,7 @@
+module "key_pair" {
+  source       = "../../../../modules/create-key-pair"
+  project_root = local.project_root
+  region_short = local.region_short
+  environment  = local.environment
+  default_tags = local.default_tags
+}

--- a/envs/dev/euw2/keypair/locals.tf
+++ b/envs/dev/euw2/keypair/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  region       = "eu-west-2"
+  region_short = "euw2"
+  environment  = "dev"
+  project_root = pathexpand("~/repos/aws-global-network")
+
+  default_tags = {
+    owning_team          = "NETENG"
+    managed_by_terraform = true
+    environment          = local.environment
+    region               = local.region
+    region_short         = local.region_short
+  }
+}

--- a/envs/dev/euw2/keypair/outputs.tf
+++ b/envs/dev/euw2/keypair/outputs.tf
@@ -1,0 +1,9 @@
+output "key_pair_name" {
+  description = "The AWS key pair name"
+  value       = module.key_pair.key_pair_name
+}
+
+output "key_pair_path" {
+  description = "Local path to the SSH private key"
+  value       = module.key_pair.private_key_path
+}

--- a/envs/dev/euw2/keypair/providers.tf
+++ b/envs/dev/euw2/keypair/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.2.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.31.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = local.region
+}

--- a/envs/prod/euw1/keypair/.terraform.lock.hcl
+++ b/envs/prod/euw1/keypair/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.33.0"
+  constraints = ">= 6.31.0"
+  hashes = [
+    "h1:wNrviem6bg9fq1bYvtGqH9QWO6iWbM1bBRLSqFJWqWM=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/prod/euw1/keypair/backend.tf
+++ b/envs/prod/euw1/keypair/backend.tf
@@ -1,7 +1,7 @@
 # A backend block cannot refer to named values (like input variables, locals, or data source attributes).
 terraform {
   backend "s3" {
-    region       = "eu-west-1"
+    region       = "eu-west-2"
     bucket       = "dmac-bootstrap-tfstate"
     key          = "env-prod/euw1/keypair/terraform.tfstate"
     encrypt      = true

--- a/envs/prod/euw2/cell0000/ec2s.tf
+++ b/envs/prod/euw2/cell0000/ec2s.tf
@@ -5,6 +5,7 @@ module "ec2" {
   environment  = local.environment
   vpc_id       = module.vpc-main.vpc.id
   vpc_name     = local.vpc_name # Dynamic from locals
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets

--- a/envs/prod/euw2/cell0000/ec2s.tf
+++ b/envs/prod/euw2/cell0000/ec2s.tf
@@ -9,7 +9,7 @@ module "ec2" {
 
   public_subnets  = module.vpc-main.public_subnets
   private_subnets = module.vpc-main.private_subnets
-  key_pair_name   = module.key_pair.key_pair_name
+  key_pair_name   = data.aws_key_pair.this.key_name
 
   # Using custom security groups from security module
   public_security_group_id  = module.security.bastion_security_group_id

--- a/envs/prod/euw2/cell0000/keypair.tf
+++ b/envs/prod/euw2/cell0000/keypair.tf
@@ -1,7 +1,3 @@
-module "key_pair" {
-  source       = "../../../../modules/create-key-pair"
-  project_root = local.project_root
-  region_short = local.region_short
-  environment  = local.environment
-  default_tags = local.default_tags
+data "aws_key_pair" "this" {
+  key_name = "kp-${local.region_short}-${local.environment}"
 }

--- a/envs/prod/euw2/cell0000/outputs.tf
+++ b/envs/prod/euw2/cell0000/outputs.tf
@@ -90,11 +90,11 @@ output "instances" {
   value = {
     bastions = {
       for k, ip in module.ec2.bastion_public_ips :
-      format("bastion-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("bastion-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
     private_hosts = {
       for k, ip in module.ec2.private_instance_private_ips :
-      format("private-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("private-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
   }
 }

--- a/envs/prod/euw2/cell0000/outputs.tf
+++ b/envs/prod/euw2/cell0000/outputs.tf
@@ -101,5 +101,5 @@ output "instances" {
 
 output "ssh_key_path" {
   description = "Local path to the SSH private key for this cell"
-  value       = module.key_pair.private_key_path
+  value       = "${local.project_root}/ssh-keys/${local.region_short}-${local.environment}.pem"
 }

--- a/envs/prod/euw2/cell0000/security.tf
+++ b/envs/prod/euw2/cell0000/security.tf
@@ -4,6 +4,7 @@ module "security" {
   vpc_cidr     = module.vpc-main.vpc.cidr_block # From VPC module output
   region_short = local.region_short
   environment  = local.environment
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]

--- a/envs/prod/euw2/cell0000/vpc.tf
+++ b/envs/prod/euw2/cell0000/vpc.tf
@@ -5,6 +5,7 @@ module "vpc-main" {
   region_short = local.region_short
   environment  = local.environment
   vpc_name     = local.vpc_name # Dynamic from locals - includes cell name
+  cell_name    = local.cell_name
   vpc_cidr     = "10.0.0.0/20"
   default_tags = local.default_tags
 

--- a/envs/prod/euw2/cell0001/ec2s.tf
+++ b/envs/prod/euw2/cell0001/ec2s.tf
@@ -5,6 +5,7 @@ module "ec2" {
   environment  = local.environment
   vpc_id       = module.vpc-main.vpc.id
   vpc_name     = local.vpc_name # Dynamic from locals
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnets  = module.vpc-main.public_subnets

--- a/envs/prod/euw2/cell0001/outputs.tf
+++ b/envs/prod/euw2/cell0001/outputs.tf
@@ -90,11 +90,11 @@ output "instances" {
   value = {
     bastions = {
       for k, ip in module.ec2.bastion_public_ips :
-      format("bastion-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("bastion-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
     private_hosts = {
       for k, ip in module.ec2.private_instance_private_ips :
-      format("private-%s-%s-%s", local.region_short, local.environment, k) => ip
+      format("private-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name) => ip
     }
   }
 }

--- a/envs/prod/euw2/cell0001/security.tf
+++ b/envs/prod/euw2/cell0001/security.tf
@@ -4,6 +4,7 @@ module "security" {
   vpc_cidr     = module.vpc-main.vpc.cidr_block # From VPC module output
   region_short = local.region_short
   environment  = local.environment
+  cell_name    = local.cell_name
   default_tags = local.default_tags
 
   public_subnet_ids  = [for k, v in module.vpc-main.public_subnets : v.id]

--- a/envs/prod/euw2/cell0001/vpc.tf
+++ b/envs/prod/euw2/cell0001/vpc.tf
@@ -5,6 +5,7 @@ module "vpc-main" {
   region_short = local.region_short
   environment  = local.environment
   vpc_name     = local.vpc_name # Dynamic from locals - includes cell name
+  cell_name    = local.cell_name
   vpc_cidr     = "10.0.16.0/20"
   default_tags = local.default_tags
 

--- a/envs/prod/euw2/keypair/.terraform.lock.hcl
+++ b/envs/prod/euw2/keypair/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.33.0"
+  constraints = ">= 6.31.0"
+  hashes = [
+    "h1:wNrviem6bg9fq1bYvtGqH9QWO6iWbM1bBRLSqFJWqWM=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/prod/euw2/keypair/backend.tf
+++ b/envs/prod/euw2/keypair/backend.tf
@@ -1,0 +1,10 @@
+# A backend block cannot refer to named values (like input variables, locals, or data source attributes).
+terraform {
+  backend "s3" {
+    region       = "eu-west-2"
+    bucket       = "dmac-bootstrap-tfstate"
+    key          = "env-prod/euw2/keypair/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/envs/prod/euw2/keypair/keypair.tf
+++ b/envs/prod/euw2/keypair/keypair.tf
@@ -1,0 +1,7 @@
+module "key_pair" {
+  source       = "../../../../modules/create-key-pair"
+  project_root = local.project_root
+  region_short = local.region_short
+  environment  = local.environment
+  default_tags = local.default_tags
+}

--- a/envs/prod/euw2/keypair/locals.tf
+++ b/envs/prod/euw2/keypair/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  region       = "eu-west-2"
+  region_short = "euw2"
+  environment  = "prod"
+  project_root = pathexpand("~/repos/aws-global-network")
+
+  default_tags = {
+    owning_team          = "NETENG"
+    managed_by_terraform = true
+    environment          = local.environment
+    region               = local.region
+    region_short         = local.region_short
+  }
+}

--- a/envs/prod/euw2/keypair/outputs.tf
+++ b/envs/prod/euw2/keypair/outputs.tf
@@ -1,0 +1,9 @@
+output "key_pair_name" {
+  description = "The AWS key pair name"
+  value       = module.key_pair.key_pair_name
+}
+
+output "key_pair_path" {
+  description = "Local path to the SSH private key"
+  value       = module.key_pair.private_key_path
+}

--- a/envs/prod/euw2/keypair/providers.tf
+++ b/envs/prod/euw2/keypair/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.2.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.31.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = local.region
+}

--- a/modules/create-ec2/bastion.tf
+++ b/modules/create-ec2/bastion.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "bastion" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("bastion-%s-%s-%s", var.region_short, var.environment, each.key)
+      Name = format("bastion-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)
       type = "bastion"
     }
   )

--- a/modules/create-ec2/private.tf
+++ b/modules/create-ec2/private.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "private" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("private-%s-%s-%s", var.region_short, var.environment, each.key)
+      Name = format("private-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)
       type = "application"
     }
   )

--- a/modules/create-ec2/variables.tf
+++ b/modules/create-ec2/variables.tf
@@ -71,3 +71,8 @@ variable "private_instance_type" {
   description = "Instance type for private instances (t2.micro is free tier eligible)"
   default     = "t2.micro"
 }
+
+variable "cell_name" {
+  type        = string
+  description = "Cell name to append to instance names for identification (e.g. cell1000)"
+}

--- a/modules/create-vpc/gateways.tf
+++ b/modules/create-vpc/gateways.tf
@@ -4,7 +4,7 @@ resource "aws_internet_gateway" "this" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("igw-%s-%s-%s", var.region_short, var.environment, var.vpc_name)
+      Name = format("igw-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     }
   )
 }
@@ -21,7 +21,7 @@ resource "awscc_ec2_nat_gateway" "this" {
     [
       {
         key   = "Name"
-        value = format("ngw-%s-%s-%s", var.region_short, var.environment, var.vpc_name)
+        value = format("ngw-%s-%s-%s", var.region_short, var.environment, var.cell_name)
       },
       {
         key   = "Type"

--- a/modules/create-vpc/routes.tf
+++ b/modules/create-vpc/routes.tf
@@ -6,7 +6,7 @@ resource "aws_route_table" "private" {
   tags = merge(
     var.default_tags,
     {
-      Name  = format("rtb-%s-%s-${each.key}", var.region_short, var.environment)
+      Name  = format("rtb-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
       scope = local.private_subnets_tag
     }
   )
@@ -36,7 +36,7 @@ resource "aws_route_table" "public" {
   tags = merge(
     var.default_tags,
     {
-      Name  = format("rtb-%s-%s-${each.key}", var.region_short, var.environment)
+      Name  = format("rtb-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
       scope = local.public_subnets_tag
     }
   )

--- a/modules/create-vpc/subnets.tf
+++ b/modules/create-vpc/subnets.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "private" {
   tags = merge(
     var.default_tags,
     {
-      Name  = format("sub-%s-%s-${each.key}", var.region_short, var.environment)
+      Name  = format("sub-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
       scope = "private"
     }
   )
@@ -37,7 +37,7 @@ resource "aws_subnet" "public" {
   tags = merge(
     var.default_tags,
     {
-      Name  = format("sub-%s-%s-${each.key}", var.region_short, var.environment)
+      Name  = format("sub-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
       scope = "public"
     }
   )

--- a/modules/create-vpc/variables.tf
+++ b/modules/create-vpc/variables.tf
@@ -25,6 +25,11 @@ variable "vpc_name" {
   description = "Name of the VPC"
 }
 
+variable "cell_name" {
+  type        = string
+  description = "Cell name for resource identification (e.g. cell1000)"
+}
+
 ## Required
 variable "vpc_cidr" {
   type        = string

--- a/modules/create-vpc/vpc.tf
+++ b/modules/create-vpc/vpc.tf
@@ -6,7 +6,7 @@ resource "aws_vpc" "this" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("vpc-%s-%s-%s", var.region_short, var.environment, var.vpc_name)
+      Name = format("vpc-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     }
   )
 }
@@ -18,7 +18,7 @@ resource "aws_egress_only_internet_gateway" "this" {
   tags = merge(
     var.default_tags,
     {
-      Name = format("egipv6-igw-%s-%s-%s", var.region_short, var.environment, var.vpc_name)
+      Name = format("egipv6-igw-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     }
   )
 }

--- a/modules/security/nacls.tf
+++ b/modules/security/nacls.tf
@@ -4,7 +4,7 @@ resource "aws_network_acl" "public" {
   subnet_ids = var.public_subnet_ids
 
   tags = merge(var.default_tags, {
-    Name = format("nacl-public-%s-%s", var.region_short, var.environment)
+    Name = format("nacl-public-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     type = "public-nacl"
   })
 }
@@ -15,7 +15,7 @@ resource "aws_network_acl" "private" {
   subnet_ids = var.private_subnet_ids
 
   tags = merge(var.default_tags, {
-    Name = format("nacl-private-%s-%s", var.region_short, var.environment)
+    Name = format("nacl-private-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     type = "private-nacl"
   })
 }

--- a/modules/security/security-groups.tf
+++ b/modules/security/security-groups.tf
@@ -40,7 +40,7 @@ resource "aws_security_group" "bastion" {
   }
 
   tags = merge(var.default_tags, {
-    Name = format("sg-bastion-%s-%s", var.region_short, var.environment)
+    Name = format("sg-bastion-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     type = "bastion-security-group"
   })
 }
@@ -81,7 +81,7 @@ resource "aws_security_group" "private" {
   }
 
   tags = merge(var.default_tags, {
-    Name = format("sg-private-%s-%s", var.region_short, var.environment)
+    Name = format("sg-private-%s-%s-%s", var.region_short, var.environment, var.cell_name)
     type = "private-security-group"
   })
 }

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -38,3 +38,8 @@ variable "env_supernet_cidr" {
   description = "Environment-level supernet CIDR (e.g. 10.1.0.0/16 for euw2-dev) allowed to communicate with private instances across cells via TGW."
   default     = ""
 }
+
+variable "cell_name" {
+  type        = string
+  description = "Cell name for resource identification (e.g. cell1000)"
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -550,7 +550,7 @@ main() {
 
   # ── Done ───────────────────────────────────────────────────────────────────
   rm -rf "$TIMING_DIR"
-  log_phase "Deployment Complete"
+  log_phase "Deployment Completed"
   log_success "All phases finished. Logs: ${LOG_DIR}"
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,8 +15,7 @@
 #
 # Deployment phases:
 #   Phase 0 (parallel) : Key pair environments (envs/{dev,prod}/<region>/keypair/)
-#   Phase 1 (parallel) : All regional TGWs + VPC cells grouped by env/region
-#                        (cells within each group deploy sequentially)
+#   Phase 1 (parallel) : All regional TGWs + all VPC cells (fully parallel)
 #   Wait               : 30 s for TGW propagation
 #   Phase 2 (parallel) : TGW-VPC Attachments (one job per region)
 #   Phase 3 (sequential): TGW Peering Attachments
@@ -144,6 +143,8 @@ run_terraform() {
   fi
 
   local rc=0
+  local t_start
+  t_start="$(date +%s)"
   if [[ "$DRY_RUN" == "true" ]]; then
     log_info "Planning: ${rel_dir}"
     (
@@ -160,16 +161,55 @@ run_terraform() {
     ) || rc=$?
   fi
 
+  local t_end
+  t_end="$(date +%s)"
+
+  # Write timing to temp file so parent process can collect it
+  # (background jobs run in subshells and can't modify parent associative arrays)
+  local timing_file="${TIMING_DIR}/$(echo "$rel_dir" | tr '/' '_')"
+  echo "${t_start} ${t_end}" > "$timing_file"
+
   if [[ $rc -eq 0 ]]; then
-    log_success "Done: ${rel_dir}"
+    log_success "Done: ${rel_dir} ($(format_duration $((t_end - t_start))))"
   else
     log_error "FAILED: ${rel_dir} — see ${log_file}"
   fi
   return $rc
 }
 
+# Reads timing temp files back into the TIMING_START/TIMING_END associative arrays.
+# Must be called in the parent process after wait_for_jobs.
+collect_timing() {
+  local f rel_dir t_start t_end
+  for f in "${TIMING_DIR}"/*; do
+    [[ -f "$f" ]] || continue
+    rel_dir="$(basename "$f" | tr '_' '/')"
+    read -r t_start t_end < "$f"
+    TIMING_START["$rel_dir"]="$t_start"
+    TIMING_END["$rel_dir"]="$t_end"
+  done
+}
+
 # ── Job tracking ──────────────────────────────────────────────────────────────
 declare -A JOB_MAP=()
+
+# ── Timing ────────────────────────────────────────────────────────────────────
+declare -A TIMING_START=()
+declare -A TIMING_END=()
+declare -A PHASE_START=()
+declare -A PHASE_END=()
+DEPLOY_START=0
+TIMING_DIR=""
+
+# Formats seconds into human-readable duration (e.g. "2m 34s")
+format_duration() {
+  local secs="$1"
+  if [[ $secs -ge 60 ]]; then
+    printf "%dm %ds" $((secs / 60)) $((secs % 60))
+  else
+    printf "%ds" "$secs"
+  fi
+}
 
 # Waits for all tracked background jobs; exits the script if any failed.
 wait_for_jobs() {
@@ -336,6 +376,58 @@ discover_tgw_peering() {
   return 0
 }
 
+# ── Timing summary ────────────────────────────────────────────────────────────
+print_timing_summary() {
+  log_phase "Deployment Timing Summary"
+
+  local total_duration=$(( DEPLOY_END - DEPLOY_START ))
+
+  # Collect and sort phase names (keys may contain spaces)
+  local sorted_phases=()
+  while IFS= read -r p; do
+    sorted_phases+=("$p")
+  done < <(printf '%s\n' "${!PHASE_START[@]}" | sort)
+
+  # Phase summary
+  echo -e "${BOLD}  Phase Durations${NC}"
+  echo -e "  ─────────────────────────────────────────────────────"
+  local phase
+  for phase in "${sorted_phases[@]}"; do
+    local p_dur=$(( PHASE_END[$phase] - PHASE_START[$phase] ))
+    printf "  %-45s %s\n" "$phase" "$(format_duration $p_dur)"
+  done
+  echo -e "  ─────────────────────────────────────────────────────"
+  printf "  ${BOLD}%-45s %s${NC}\n" "Total" "$(format_duration $total_duration)"
+  echo ""
+
+  # Collect and sort directory names
+  local sorted_dirs=()
+  while IFS= read -r d; do
+    sorted_dirs+=("$d")
+  done < <(printf '%s\n' "${!TIMING_START[@]}" | sort)
+
+  # Per-directory breakdown grouped by phase
+  for phase in "${sorted_phases[@]}"; do
+    echo -e "${BOLD}  ${phase} — Breakdown${NC}"
+    echo -e "  ─────────────────────────────────────────────────────"
+
+    local dir
+    for dir in "${sorted_dirs[@]}"; do
+      local d_start="${TIMING_START[$dir]}"
+      local d_end="${TIMING_END[$dir]}"
+      local p_start="${PHASE_START[$phase]}"
+      local p_end="${PHASE_END[$phase]}"
+
+      # Dir belongs to this phase if it started within the phase window
+      if [[ $d_start -ge $p_start && $d_start -le $p_end ]]; then
+        local d_dur=$(( d_end - d_start ))
+        printf "    %-43s %s\n" "$dir" "$(format_duration $d_dur)"
+      fi
+    done
+    echo ""
+  done
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 main() {
   cd "$REPO_ROOT"
@@ -343,6 +435,8 @@ main() {
   rotate_logs
 
   log_phase "AWS Global Network — Parallel Deployment"
+  DEPLOY_START="$(date +%s)"
+  TIMING_DIR="$(mktemp -d)"
   log_info "Repo root    : ${REPO_ROOT}"
   log_info "Log dir      : ${LOG_DIR}"
   log_info "Environments : ${ENVIRONMENTS[*]}"
@@ -367,6 +461,7 @@ main() {
   # ── Phase 0: Key pair environments (parallel across regions) ───────────────
   if [[ ${#KEYPAIRS[@]} -gt 0 ]]; then
     log_phase "Phase 0 — SSH Key Pairs (parallel across regions)"
+    PHASE_START["Phase 0 — SSH Key Pairs"]="$(date +%s)"
 
     local dir
     for dir in "${KEYPAIRS[@]}"; do
@@ -375,6 +470,8 @@ main() {
     done
 
     wait_for_jobs "Phase 0"
+    collect_timing
+    PHASE_END["Phase 0 — SSH Key Pairs"]="$(date +%s)"
     log_success "Phase 0 complete."
   fi
 
@@ -382,7 +479,8 @@ main() {
   # TGWs run in parallel. VPC cells are grouped by env/region and run
   # sequentially within each group (to respect key pair creation order),
   # but groups themselves run in parallel across regions/environments.
-  log_phase "Phase 1 — VPCs + TGWs (cells sequential within env/region)"
+  log_phase "Phase 1 — VPCs + TGWs (all parallel)"
+  PHASE_START["Phase 1 — VPCs + TGWs"]="$(date +%s)"
 
   # TGWs start immediately in parallel
   local dir
@@ -391,25 +489,16 @@ main() {
     JOB_MAP[$!]="$dir"
   done
 
-  # Group cells by env/region key (e.g. envs/dev/euw2)
-  declare -A CELL_GROUPS=()
-  local cell group_key
+  # All VPC cells deploy in parallel — keypairs are already created in Phase 0
+  local cell
   for cell in "${VPC_CELLS[@]}"; do
-    group_key="$(echo "$cell" | cut -d/ -f1-3)"
-    CELL_GROUPS["$group_key"]+="$cell "
-  done
-
-  # Each group runs as a single background job; cells within the group are sequential
-  for group_key in "${!CELL_GROUPS[@]}"; do
-    (
-      for cell in $(echo "${CELL_GROUPS[$group_key]}" | tr ' ' '\n' | sort); do
-        run_terraform "$cell"
-      done
-    ) &
-    JOB_MAP[$!]="$group_key"
+    run_terraform "$cell" &
+    JOB_MAP[$!]="$cell"
   done
 
   wait_for_jobs "Phase 1"
+  collect_timing
+  PHASE_END["Phase 1 — VPCs + TGWs"]="$(date +%s)"
   log_success "Phase 1 complete."
 
   # ── 30-second TGW stabilisation wait ───────────────────────────────────────
@@ -421,6 +510,7 @@ main() {
   # ── Phase 2: TGW-VPC Attachments in parallel (one per region) ──────────────
   if [[ ${#TGW_ATTS[@]} -gt 0 ]]; then
     log_phase "Phase 2 — TGW-VPC Attachments (parallel)"
+    PHASE_START["Phase 2 — TGW-VPC Attachments"]="$(date +%s)"
 
     for dir in "${TGW_ATTS[@]}"; do
       run_terraform "$dir" &
@@ -428,6 +518,8 @@ main() {
     done
 
     wait_for_jobs "Phase 2"
+    collect_timing
+    PHASE_END["Phase 2 — TGW-VPC Attachments"]="$(date +%s)"
     log_success "Phase 2 complete."
   else
     log_warn "No TGW-VPC Attachment directories found — skipping Phase 2."
@@ -436,12 +528,15 @@ main() {
   # ── Phase 3: TGW Peering Attachments (sequential) ──────────────────────────
   if [[ "$SKIP_PEERING" == "false" && ${#TGW_PEERING[@]} -gt 0 ]]; then
     log_phase "Phase 3 — TGW Peering Attachments (sequential)"
+    PHASE_START["Phase 3 — TGW Peering"]="$(date +%s)"
 
     for dir in "${TGW_PEERING[@]}"; do
       run_terraform "$dir"
     done
 
     log_success "Phase 3 complete."
+    collect_timing
+    PHASE_END["Phase 3 — TGW Peering"]="$(date +%s)"
   else
     log_warn "No TGW Peering directories found (or --skip-peering set) — skipping Phase 3."
   fi
@@ -449,7 +544,12 @@ main() {
   # ── Instance inventory ─────────────────────────────────────────────────────
   print_instance_inventory
 
+  # ── Timing summary ──────────────────────────────────────────────────────────
+  DEPLOY_END="$(date +%s)"
+  print_timing_summary
+
   # ── Done ───────────────────────────────────────────────────────────────────
+  rm -rf "$TIMING_DIR"
   log_phase "Deployment Complete"
   log_success "All phases finished. Logs: ${LOG_DIR}"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -451,7 +451,7 @@ main() {
   mapfile -t TGW_ATTS    < <(discover_tgw_vpc_atts)
   mapfile -t TGW_PEERING < <(discover_tgw_peering)
 
-  log_info "Found: ${#KEYPAIRS[@]} key pair env(s) | ${#VPC_CELLS[@]} VPC cell(s) | ${#TGWS[@]} TGW(s) | ${#TGW_ATTS[@]} attachment group(s) | ${#TGW_PEERING[@]} peering group(s)"
+  log_info "Found: SSH Key Pairs (${#KEYPAIRS[@]}) | VPC (${#VPC_CELLS[@]}) | TGW (${#TGWS[@]}) | TGW-VPC Atts (${#VPC_CELLS[@]}) | TGW PCX (${#TGW_PEERING[@]})"
 
   if [[ ${#KEYPAIRS[@]} -eq 0 && ${#VPC_CELLS[@]} -eq 0 && ${#TGWS[@]} -eq 0 ]]; then
     log_warn "Nothing to deploy. Check --environment and --regions filters."
@@ -460,7 +460,7 @@ main() {
 
   # ── Phase 0: Key pair environments (parallel across regions) ───────────────
   if [[ ${#KEYPAIRS[@]} -gt 0 ]]; then
-    log_phase "Phase 0 — SSH Key Pairs (parallel across regions)"
+    log_phase "Phase 0 — SSH Key Pairs"
     PHASE_START["Phase 0 — SSH Key Pairs"]="$(date +%s)"
 
     local dir
@@ -479,7 +479,7 @@ main() {
   # TGWs run in parallel. VPC cells are grouped by env/region and run
   # sequentially within each group (to respect key pair creation order),
   # but groups themselves run in parallel across regions/environments.
-  log_phase "Phase 1 — VPCs + TGWs (all parallel)"
+  log_phase "Phase 1 — VPCs + TGWs"
   PHASE_START["Phase 1 — VPCs + TGWs"]="$(date +%s)"
 
   # TGWs start immediately in parallel
@@ -509,7 +509,7 @@ main() {
 
   # ── Phase 2: TGW-VPC Attachments in parallel (one per region) ──────────────
   if [[ ${#TGW_ATTS[@]} -gt 0 ]]; then
-    log_phase "Phase 2 — TGW-VPC Attachments (parallel)"
+    log_phase "Phase 2 — TGW-VPC Attachments"
     PHASE_START["Phase 2 — TGW-VPC Attachments"]="$(date +%s)"
 
     for dir in "${TGW_ATTS[@]}"; do
@@ -527,7 +527,7 @@ main() {
 
   # ── Phase 3: TGW Peering Attachments (sequential) ──────────────────────────
   if [[ "$SKIP_PEERING" == "false" && ${#TGW_PEERING[@]} -gt 0 ]]; then
-    log_phase "Phase 3 — TGW Peering Attachments (sequential)"
+    log_phase "Phase 3 — TGW Peering Attachments"
     PHASE_START["Phase 3 — TGW Peering"]="$(date +%s)"
 
     for dir in "${TGW_PEERING[@]}"; do

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -491,7 +491,7 @@ main() {
 
   # ── Done ───────────────────────────────────────────────────────────────────
   rm -rf "$TIMING_DIR"
-  log_phase "Teardown Complete"
+  log_phase "Destroy Completed"
   log_success "All phases finished. Logs: ${LOG_DIR}"
 }
 

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -143,6 +143,8 @@ run_terraform() {
   fi
 
   local rc=0
+  local t_start
+  t_start="$(date +%s)"
   if [[ "$DRY_RUN" == "true" ]]; then
     log_info "Planning destroy: ${rel_dir}"
     (
@@ -159,8 +161,16 @@ run_terraform() {
     ) || rc=$?
   fi
 
+  local t_end
+  t_end="$(date +%s)"
+
+  # Write timing to temp file so parent process can collect it
+  # (background jobs run in subshells and can't modify parent associative arrays)
+  local timing_file="${TIMING_DIR}/$(echo "$rel_dir" | tr '/' '_')"
+  echo "${t_start} ${t_end}" > "$timing_file"
+
   if [[ $rc -eq 0 ]]; then
-    log_success "Done: ${rel_dir}"
+    log_success "Done: ${rel_dir} ($(format_duration $((t_end - t_start))))"
   else
     log_error "FAILED: ${rel_dir} — see ${log_file}"
   fi
@@ -169,6 +179,37 @@ run_terraform() {
 
 # ── Job tracking ──────────────────────────────────────────────────────────────
 declare -A JOB_MAP=()
+
+# ── Timing ────────────────────────────────────────────────────────────────────
+declare -A TIMING_START=()
+declare -A TIMING_END=()
+declare -A PHASE_START=()
+declare -A PHASE_END=()
+DEPLOY_START=0
+TIMING_DIR=""
+
+# Formats seconds into human-readable duration (e.g. "2m 34s")
+format_duration() {
+  local secs="$1"
+  if [[ $secs -ge 60 ]]; then
+    printf "%dm %ds" $((secs / 60)) $((secs % 60))
+  else
+    printf "%ds" "$secs"
+  fi
+}
+
+# Reads timing temp files back into the TIMING_START/TIMING_END associative arrays.
+# Must be called in the parent process after wait_for_jobs.
+collect_timing() {
+  local f rel_dir t_start t_end
+  for f in "${TIMING_DIR}"/*; do
+    [[ -f "$f" ]] || continue
+    rel_dir="$(basename "$f" | tr '_' '/')"
+    read -r t_start t_end < "$f"
+    TIMING_START["$rel_dir"]="$t_start"
+    TIMING_END["$rel_dir"]="$t_end"
+  done
+}
 
 # Waits for all tracked background jobs; exits the script if any failed.
 wait_for_jobs() {
@@ -288,6 +329,58 @@ discover_tgw_peering() {
   return 0
 }
 
+# ── Timing summary ────────────────────────────────────────────────────────────
+print_timing_summary() {
+  log_phase "Teardown Timing Summary"
+
+  local total_duration=$(( DEPLOY_END - DEPLOY_START ))
+
+  # Collect and sort phase names (keys may contain spaces)
+  local sorted_phases=()
+  while IFS= read -r p; do
+    sorted_phases+=("$p")
+  done < <(printf '%s\n' "${!PHASE_START[@]}" | sort)
+
+  # Phase summary
+  echo -e "${BOLD}  Phase Durations${NC}"
+  echo -e "  ─────────────────────────────────────────────────────"
+  local phase
+  for phase in "${sorted_phases[@]}"; do
+    local p_dur=$(( PHASE_END[$phase] - PHASE_START[$phase] ))
+    printf "  %-45s %s\n" "$phase" "$(format_duration $p_dur)"
+  done
+  echo -e "  ─────────────────────────────────────────────────────"
+  printf "  ${BOLD}%-45s %s${NC}\n" "Total" "$(format_duration $total_duration)"
+  echo ""
+
+  # Collect and sort directory names
+  local sorted_dirs=()
+  while IFS= read -r d; do
+    sorted_dirs+=("$d")
+  done < <(printf '%s\n' "${!TIMING_START[@]}" | sort)
+
+  # Per-directory breakdown grouped by phase
+  for phase in "${sorted_phases[@]}"; do
+    echo -e "${BOLD}  ${phase} — Breakdown${NC}"
+    echo -e "  ─────────────────────────────────────────────────────"
+
+    local dir
+    for dir in "${sorted_dirs[@]}"; do
+      local d_start="${TIMING_START[$dir]}"
+      local d_end="${TIMING_END[$dir]}"
+      local p_start="${PHASE_START[$phase]}"
+      local p_end="${PHASE_END[$phase]}"
+
+      # Dir belongs to this phase if it started within the phase window
+      if [[ $d_start -ge $p_start && $d_start -le $p_end ]]; then
+        local d_dur=$(( d_end - d_start ))
+        printf "    %-43s %s\n" "$dir" "$(format_duration $d_dur)"
+      fi
+    done
+    echo ""
+  done
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 main() {
   cd "$REPO_ROOT"
@@ -295,6 +388,8 @@ main() {
   rotate_logs
 
   log_phase "AWS Global Network — Parallel Teardown"
+  DEPLOY_START="$(date +%s)"
+  TIMING_DIR="$(mktemp -d)"
   log_info "Repo root    : ${REPO_ROOT}"
   log_info "Log dir      : ${LOG_DIR}"
   log_info "Environments : ${ENVIRONMENTS[*]}"
@@ -309,7 +404,7 @@ main() {
   mapfile -t TGW_ATTS    < <(discover_tgw_vpc_atts)
   mapfile -t TGW_PEERING < <(discover_tgw_peering)
 
-  log_info "Found: ${#KEYPAIRS[@]} key pair env(s) | ${#VPC_CELLS[@]} VPC cell(s) | ${#TGWS[@]} TGW(s) | ${#TGW_ATTS[@]} attachment group(s) | ${#TGW_PEERING[@]} peering group(s)"
+  log_info "Found: SSH Key Pairs (${#KEYPAIRS[@]}) | VPC (${#VPC_CELLS[@]}) | TGW (${#TGWS[@]}) | TGW-VPC Atts (${#VPC_CELLS[@]}) | TGW PCX (${#TGW_PEERING[@]})"
 
   if [[ ${#KEYPAIRS[@]} -eq 0 && ${#VPC_CELLS[@]} -eq 0 && ${#TGWS[@]} -eq 0 ]]; then
     log_warn "Nothing to destroy. Check --environment and --regions filters."
@@ -318,13 +413,16 @@ main() {
 
   # ── Phase 1: TGW Peering Attachments (sequential) ──────────────────────────
   if [[ "$SKIP_PEERING" == "false" && ${#TGW_PEERING[@]} -gt 0 ]]; then
-    log_phase "Phase 1 — TGW Peering Attachments (sequential)"
+    log_phase "Phase 1 — TGW Peering Attachments"
+    PHASE_START["Phase 1 — TGW Peering"]="$(date +%s)"
 
     local dir
     for dir in "${TGW_PEERING[@]}"; do
       run_terraform "$dir"
     done
 
+    collect_timing
+    PHASE_END["Phase 1 — TGW Peering"]="$(date +%s)"
     log_success "Phase 1 complete."
   else
     log_warn "No TGW Peering directories found (or --skip-peering set) — skipping Phase 1."
@@ -332,7 +430,8 @@ main() {
 
   # ── Phase 2: TGW-VPC Attachments in parallel (one per region) ──────────────
   if [[ ${#TGW_ATTS[@]} -gt 0 ]]; then
-    log_phase "Phase 2 — TGW-VPC Attachments (parallel)"
+    log_phase "Phase 2 — TGW-VPC Attachments"
+    PHASE_START["Phase 2 — TGW-VPC Attachments"]="$(date +%s)"
 
     local dir
     for dir in "${TGW_ATTS[@]}"; do
@@ -341,6 +440,8 @@ main() {
     done
 
     wait_for_jobs "Phase 2"
+    collect_timing
+    PHASE_END["Phase 2 — TGW-VPC Attachments"]="$(date +%s)"
     log_success "Phase 2 complete."
   else
     log_warn "No TGW-VPC Attachment directories found — skipping Phase 2."
@@ -353,7 +454,8 @@ main() {
   fi
 
   # ── Phase 3: TGWs + VPCs in parallel ───────────────────────────────────────
-  log_phase "Phase 3 — TGWs + VPCs (parallel)"
+  log_phase "Phase 3 — TGWs + VPCs"
+  PHASE_START["Phase 3 — TGWs + VPCs"]="$(date +%s)"
 
   local dir
   for dir in "${TGWS[@]}" "${VPC_CELLS[@]}"; do
@@ -362,11 +464,14 @@ main() {
   done
 
   wait_for_jobs "Phase 3"
+  collect_timing
+  PHASE_END["Phase 3 — TGWs + VPCs"]="$(date +%s)"
   log_success "Phase 3 complete."
 
   # ── Phase 4: SSH Key Pairs (parallel) — destroyed last ─────────────────────
   if [[ ${#KEYPAIRS[@]} -gt 0 ]]; then
-    log_phase "Phase 4 — SSH Key Pairs (parallel — destroyed last)"
+    log_phase "Phase 4 — SSH Key Pairs"
+    PHASE_START["Phase 4 — SSH Key Pairs"]="$(date +%s)"
 
     local dir
     for dir in "${KEYPAIRS[@]}"; do
@@ -375,10 +480,17 @@ main() {
     done
 
     wait_for_jobs "Phase 4"
+    collect_timing
+    PHASE_END["Phase 4 — SSH Key Pairs"]="$(date +%s)"
     log_success "Phase 4 complete."
   fi
 
+  # ── Timing summary ──────────────────────────────────────────────────────────
+  DEPLOY_END="$(date +%s)"
+  print_timing_summary
+
   # ── Done ───────────────────────────────────────────────────────────────────
+  rm -rf "$TIMING_DIR"
   log_phase "Teardown Complete"
   log_success "All phases finished. Logs: ${LOG_DIR}"
 }

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -62,6 +62,62 @@ usw2: 64517
 
 
 
-## State files
-- One State file for VPCs and EC2
-- Another State file for 
+## Naming Convention
+
+All AWS resources follow a consistent naming pattern for the `Name` tag to enable easy identification in the AWS Console, especially when multiple cells coexist in the same region.
+
+### General Pattern
+
+```
+{resource_shortname}-{region_short}-{environment}-{optional_info}-{cell_name}
+```
+
+- `resource_shortname`: Short identifier for the resource type (see table below)
+- `region_short`: AWS region short code (euw2, euw1, usw2, etc.)
+- `environment`: Environment name (prod, dev)
+- `optional_info`: Context-specific info like subnet key (pub-0, priv-1, etc.)
+- `cell_name`: The cell identifier (cell0000, cell1000, etc.)
+
+### Cell-Scoped Resources
+
+These resources belong to a specific VPC/cell and include `cell_name` in their Name tag:
+
+| Resource | Shortname | Name Pattern | Example |
+|----------|-----------|-------------|---------|
+| VPC | vpc | `vpc-{region_short}-{env}-{cell}` | vpc-euw2-prod-cell0000 |
+| Internet Gateway | igw | `igw-{region_short}-{env}-{cell}` | igw-euw2-dev-cell1000 |
+| Egress-only IPv6 IGW | egipv6-igw | `egipv6-igw-{region_short}-{env}-{cell}` | egipv6-igw-euw2-dev-cell1000 |
+| NAT Gateway | ngw | `ngw-{region_short}-{env}-{cell}` | ngw-euw2-prod-cell0000 |
+| Subnet | sub | `sub-{region_short}-{env}-{subnet_key}-{cell}` | sub-euw2-dev-priv-2-cell1000 |
+| Route Table | rtb | `rtb-{region_short}-{env}-{subnet_key}-{cell}` | rtb-euw2-dev-priv-2-cell1000 |
+| Bastion EC2 | bastion | `bastion-{region_short}-{env}-{subnet_key}-{cell}` | bastion-euw2-prod-pub-0-cell0000 |
+| Private EC2 | private | `private-{region_short}-{env}-{subnet_key}-{cell}` | private-euw2-prod-priv-1-cell0000 |
+| Bastion Security Group | sg-bastion | `sg-bastion-{region_short}-{env}-{cell}` | sg-bastion-euw2-dev-cell1000 |
+| Private Security Group | sg-private | `sg-private-{region_short}-{env}-{cell}` | sg-private-euw2-dev-cell1000 |
+| Public NACL | nacl-public | `nacl-public-{region_short}-{env}-{cell}` | nacl-public-euw2-prod-cell0000 |
+| Private NACL | nacl-private | `nacl-private-{region_short}-{env}-{cell}` | nacl-private-euw2-prod-cell0000 |
+
+### Singleton/Shared Resources (no cell_name)
+
+Resources that are shared across cells or are region-wide singletons do NOT include `cell_name`:
+
+| Resource | Shortname | Name Pattern | Example |
+|----------|-----------|-------------|---------|
+| Transit Gateway | tgw | `tgw-{region_short}` | tgw-euw2 |
+| TGW Route Table | rt-tgw | `rt-tgw-{region_short}-{env}` | rt-tgw-euw2-dev |
+| TGW Attachment | tgw-att | `tgw-att-{region_short}-{env}-{vpc_name}` | tgw-att-euw2-dev-main |
+| Key Pair | kp | `kp-{region_short}-{env}` | kp-euw2-dev |
+
+### Rationale
+
+- Including `cell_name` in per-cell resources makes it possible to distinguish resources from different cells when viewing them in the same region in the AWS Console.
+- Singleton resources (TGW, key pairs) exist once per region or per region/environment, so `cell_name` would be redundant.
+- The pattern is consistent and sortable — resources group naturally by type, region, and environment in alphabetical listings.
+
+## State Files
+
+- Each VPC cell has its own state file: `env-{environment}/{region_short}/{cell_name}/terraform.tfstate`
+- TGW core has a separate state file: `env-networking/{region_short}-tgw/terraform.tfstate`
+- TGW VPC attachments have a separate state file: `env-networking/{region_short}-tgw-vpc-atts/terraform.tfstate`
+- Key pairs have a separate state file per environment/region: `env-{environment}/{region_short}/keypair/terraform.tfstate`
+- Cross-state references use `terraform_remote_state` data sources


### PR DESCRIPTION
# PR: EUW2 SSH Key Pairs + Resource Naming Fixes + Deploy Timing Summary

**Branch:** `feature/euw2-keypairs` → `main`

## Overview

This PR introduces standalone SSH key pair Terraform environments for `eu-west-2` (dev and prod), decouples key pair creation from VPC cell environments by replacing inline `module "key_pair"` blocks with `data "aws_key_pair"` lookups, fixes the `cell_name` suffix in all resource Name tags across shared modules, and adds a deployment timing summary to both `deploy.sh` and `destroy.sh`.

---

## Changes

### New: EUW2 Keypair Environments

Two new standalone Terraform root modules are added for SSH key pair management in `eu-west-2`:

- `envs/dev/euw2/keypair/` — deploys `kp-euw2-dev`
- `envs/prod/euw2/keypair/` — deploys `kp-euw2-prod`

Each environment contains:

| File | Purpose |
|---|---|
| `backend.tf` | S3 remote state (`env-{dev,prod}/euw2/keypair/terraform.tfstate`) |
| `keypair.tf` | Calls `modules/create-key-pair` with region/env locals |
| `locals.tf` | Defines `region`, `region_short`, `environment`, `project_root`, and `default_tags` |
| `outputs.tf` | Exposes `key_pair_name` and `key_pair_path` |
| `providers.tf` | Pins `aws >= 6.31.0`, `tls >= 4.0.0`, `local >= 2.0.0`, `null >= 3.0.0` |
| `.terraform.lock.hcl` | Provider hash lock file (AWS 6.33.0) |

The EUW1 keypair backends also received a backend region fix (`cf26e59`).

### Refactor: Cell Environments Now Reference Keypairs via Data Source

VPC cell environments previously created their own key pair by calling `module "key_pair"` inline. They now assume the key pair already exists (created in Phase 0 by the dedicated keypair environment) and look it up with a data source:

```hcl
# Before (envs/dev/euw2/cell1000/keypair.tf)
module "key_pair" {
  source       = "../../../../modules/create-key-pair"
  project_root = local.project_root
  region_short = local.region_short
  environment  = local.environment
  default_tags = local.default_tags
}

# After
data "aws_key_pair" "this" {
  key_name = "kp-${local.region_short}-${local.environment}"
}
```

This pattern is applied to all four affected cell environments:
- `envs/dev/euw2/cell1000/`
- `envs/dev/euw2/cell1001/`
- `envs/prod/euw2/cell0000/`
- `envs/prod/euw2/cell0001/`

The `ssh_key_path` output is updated accordingly to derive the path directly from locals instead of referencing the now-removed module output.

Instance output maps now include `cell_name` in the key format:

```hcl
# Before
format("bastion-%s-%s-%s", local.region_short, local.environment, k)
# After
format("bastion-%s-%s-%s-%s", local.region_short, local.environment, k, local.cell_name)
```

### Fix: `cell_name` Added to All Module Resource Name Tags

All shared modules were missing `cell_name` from their `Name` tag format strings, making resources from different cells indistinguishable. The `cell_name` variable was added to three modules and wired through to every resource Name tag:

**`modules/create-vpc/`**

```hcl
# vpc.tf
Name = format("vpc-%s-%s-%s", var.region_short, var.environment, var.cell_name)

# gateways.tf
Name = format("igw-%s-%s-%s", var.region_short, var.environment, var.cell_name)
Name = format("ngw-%s-%s-%s", var.region_short, var.environment, var.cell_name)

# subnets.tf
Name = format("sub-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)

# routes.tf
Name = format("rtb-%s-%s-${each.key}-%s", var.region_short, var.environment, var.cell_name)
```

**`modules/security/`**

```hcl
# nacls.tf
Name = format("nacl-public-%s-%s-%s",  var.region_short, var.environment, var.cell_name)
Name = format("nacl-private-%s-%s-%s", var.region_short, var.environment, var.cell_name)

# security-groups.tf
Name = format("sg-bastion-%s-%s-%s",  var.region_short, var.environment, var.cell_name)
Name = format("sg-private-%s-%s-%s",  var.region_short, var.environment, var.cell_name)
```

**`modules/create-ec2/`**

```hcl
# bastion.tf
Name = format("bastion-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)

# private.tf
Name = format("private-%s-%s-%s-%s", var.region_short, var.environment, each.key, var.cell_name)
```

All three modules received a new `cell_name` variable definition (`type = string`, with description).

### Enhancement: Deployment Timing Summary in `deploy.sh` and `destroy.sh`

Both scripts now record wall-clock timing for every Terraform invocation and each deployment phase, then print a summary table at the end of each run.

Key implementation details:

- `run_terraform()` captures `t_start` / `t_end` timestamps and writes them to a temp file in `$TIMING_DIR` (using `tr '/' '_'` to encode directory paths as filenames). This sidesteps the subshell limitation of background jobs.
- `collect_timing()` reads those temp files back into `TIMING_START` / `TIMING_END` associative arrays in the parent process after each `wait_for_jobs` call.
- `format_duration()` converts seconds to a human-readable `Nm Ns` string.
- `print_timing_summary()` renders a phase summary table followed by a per-directory breakdown grouped by phase.
- `PHASE_START` / `PHASE_END` associative arrays bookend each phase block.
- `TIMING_DIR` is cleaned up with `rm -rf` before the script exits.

The done log lines now include inline durations:

```
[SUCCESS] Done: envs/dev/euw2/cell1000 (1m 42s)
```

**`deploy.sh` also changes Phase 1 cell parallelism:** VPC cells previously ran sequentially within an env/region group. Since key pairs are now guaranteed to exist before Phase 1 starts (created in Phase 0), all VPC cells now deploy fully in parallel.

Phase log labels had redundant parenthetical descriptions removed for cleaner output (e.g. `"Phase 2 — TGW-VPC Attachments"` instead of `"Phase 2 — TGW-VPC Attachments (parallel)"`).

The discovery summary log line format was also updated in both scripts:

```
# Before
Found: 2 key pair env(s) | 4 VPC cell(s) | 2 TGW(s) | 2 attachment group(s) | 1 peering group(s)
# After
Found: SSH Key Pairs (2) | VPC (4) | TGW (2) | TGW-VPC Atts (4) | TGW PCX (1)
```

---

## Files Changed

### New Files
- `envs/dev/euw2/keypair/backend.tf`
- `envs/dev/euw2/keypair/keypair.tf`
- `envs/dev/euw2/keypair/locals.tf`
- `envs/dev/euw2/keypair/outputs.tf`
- `envs/dev/euw2/keypair/providers.tf`
- `envs/dev/euw2/keypair/.terraform.lock.hcl`
- `envs/prod/euw2/keypair/backend.tf`
- `envs/prod/euw2/keypair/keypair.tf`
- `envs/prod/euw2/keypair/locals.tf`
- `envs/prod/euw2/keypair/outputs.tf`
- `envs/prod/euw2/keypair/providers.tf`
- `envs/prod/euw2/keypair/.terraform.lock.hcl`

### Modified Files
- `envs/dev/euw1/keypair/backend.tf` — fix backend region
- `envs/prod/euw1/keypair/backend.tf` — fix backend region
- `envs/dev/euw2/cell1000/{keypair,ec2s,outputs,security,vpc}.tf` — data source reference + cell_name wiring
- `envs/dev/euw2/cell1001/{ec2s,outputs,security,vpc}.tf` — cell_name wiring
- `envs/prod/euw2/cell0000/{keypair,ec2s,outputs,security,vpc}.tf` — data source reference + cell_name wiring
- `envs/prod/euw2/cell0001/{ec2s,outputs,security,vpc}.tf` — cell_name wiring
- `modules/create-vpc/{variables,gateways,routes,subnets,vpc}.tf` — add cell_name variable + fix Name tags
- `modules/security/{variables,nacls,security-groups}.tf` — add cell_name variable + fix Name tags
- `modules/create-ec2/{variables,bastion,private}.tf` — add cell_name variable + fix Name tags
- `scripts/deploy.sh` — timing infrastructure + parallel Phase 1 cells
- `scripts/destroy.sh` — timing infrastructure

---

## Testing

- `terraform validate` should pass on all modified environments and modules.
- `terraform fmt --recursive` has been applied.
- Dry-run (`--dry-run` flag) can be used to verify plan output and timing summary without applying.

---