### PR TITLE
CI Pipeline - Infracost fix

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   INFRACOST_ENABLE_CLOUD: false
   AWS_DEFAULT_REGION: eu-west-2
+  TF_CLI_ARGS_init: "-backend=false"
 
 jobs:
   # -----------------------------------------------------------------------
@@ -45,7 +46,6 @@ jobs:
         run: |
           infracost breakdown \
             --config-file=infracost.yml \
-            --terraform-init-flags="-backend=false" \
             --format=json \
             --out-file=/tmp/infracost-base.json
 
@@ -63,7 +63,6 @@ jobs:
         run: |
           infracost diff \
             --config-file=infracost.yml \
-            --terraform-init-flags="-backend=false" \
             --format=json \
             --compare-to=/tmp/infracost-base.json \
             --out-file=/tmp/infracost.json
@@ -105,5 +104,4 @@ jobs:
         run: |
           infracost breakdown \
             --config-file=infracost.yml \
-            --terraform-init-flags="-backend=false" \
             --format=table

--- a/envs/dev/euw1/cell3000/ec2s.tf
+++ b/envs/dev/euw1/cell3000/ec2s.tf
@@ -1,17 +1,17 @@
-module "ec2" {
-  source       = "../../../../modules/create-ec2"
-  region       = local.region
-  region_short = local.region_short
-  environment  = local.environment
-  vpc_id       = module.vpc-main.vpc.id
-  vpc_name     = local.vpc_name
-  cell_name    = local.cell_name
-  default_tags = local.default_tags
+#module "ec2" {
+  #source       = "../../../../modules/create-ec2"
+  #region       = local.region
+  #region_short = local.region_short
+  #environment  = local.environment
+  #vpc_id       = module.vpc-main.vpc.id
+  #vpc_name     = local.vpc_name
+  #cell_name    = local.cell_name
+  #default_tags = local.default_tags
 
-  public_subnets  = module.vpc-main.public_subnets
-  private_subnets = module.vpc-main.private_subnets
-  key_pair_name   = data.aws_key_pair.this.key_name
+  #public_subnets  = module.vpc-main.public_subnets
+  #private_subnets = module.vpc-main.private_subnets
+  #key_pair_name   = data.aws_key_pair.this.key_name
 
-  public_security_group_id  = module.security.bastion_security_group_id
-  private_security_group_id = module.security.private_security_group_id
-}
+  #public_security_group_id  = module.security.bastion_security_group_id
+  #private_security_group_id = module.security.private_security_group_id
+#}

--- a/envs/dev/euw1/cell3000/ec2s.tf
+++ b/envs/dev/euw1/cell3000/ec2s.tf
@@ -1,17 +1,17 @@
-#module "ec2" {
-  #source       = "../../../../modules/create-ec2"
-  #region       = local.region
-  #region_short = local.region_short
-  #environment  = local.environment
-  #vpc_id       = module.vpc-main.vpc.id
-  #vpc_name     = local.vpc_name
-  #cell_name    = local.cell_name
-  #default_tags = local.default_tags
+module "ec2" {
+  source       = "../../../../modules/create-ec2"
+  region       = local.region
+  region_short = local.region_short
+  environment  = local.environment
+  vpc_id       = module.vpc-main.vpc.id
+  vpc_name     = local.vpc_name
+  cell_name    = local.cell_name
+  default_tags = local.default_tags
 
-  #public_subnets  = module.vpc-main.public_subnets
-  #private_subnets = module.vpc-main.private_subnets
-  #key_pair_name   = data.aws_key_pair.this.key_name
+  public_subnets  = module.vpc-main.public_subnets
+  private_subnets = module.vpc-main.private_subnets
+  key_pair_name   = data.aws_key_pair.this.key_name
 
-  #public_security_group_id  = module.security.bastion_security_group_id
-  #private_security_group_id = module.security.private_security_group_id
-#}
+  public_security_group_id  = module.security.bastion_security_group_id
+  private_security_group_id = module.security.private_security_group_id
+}


### PR DESCRIPTION
## TLDR

Fixes the Infracost GitHub Actions pipeline by replacing the deprecated
`--terraform-init-flags` CLI argument with the standard `TF_CLI_ARGS_init`
environment variable. This ensures Terraform backend initialisation is
correctly skipped during cost estimation across all three pipeline steps.

---

## Description

The Infracost pipeline was using the `--terraform-init-flags="-backend=false"`
flag directly on each `infracost breakdown` and `infracost diff` invocation.
This flag was either deprecated or unsupported in the version of Infracost
being used, causing the pipeline to fail when attempting to render the
Terraform plan for cost analysis.

The fix moves the backend-disabling directive to the environment level by
setting `TF_CLI_ARGS_init: "-backend=false"` as a workflow-level environment
variable. Terraform automatically picks up `TF_CLI_ARGS_*` variables during
the corresponding subcommand (`init` in this case), making the configuration
cleaner, less repetitive, and correctly honoured by Infracost when it invokes
`terraform init` internally.

This change also removes duplicated flags from three separate `run:` steps,
reducing maintenance overhead and keeping the pipeline DRY.

---

## Key Changes

- **`.github/workflows/pipeline.yml`**
  - Added `TF_CLI_ARGS_init: "-backend=false"` to the workflow-level `env:`
    block so all jobs inherit it automatically.
  - Removed `--terraform-init-flags="-backend=false"` from the
    `infracost breakdown` step in **Job 1** (cost estimate baseline).
  - Removed `--terraform-init-flags="-backend=false"` from the
    `infracost diff` step in **Job 1** (cost diff generation).
  - Removed `--terraform-init-flags="-backend=false"` from the
    `infracost breakdown` step in **Job 2** (baseline update on push to main).
